### PR TITLE
Support for providing TypeRuntimeWirings

### DIFF
--- a/src/main/java/graphql/nadel/Nadel.java
+++ b/src/main/java/graphql/nadel/Nadel.java
@@ -86,9 +86,11 @@ public class Nadel {
         }
 
         AsyncExecutionStrategy asyncExecutionStrategy = new AsyncExecutionStrategy();
+        final TypeDefinitionsWithRuntimeWiring typesWithWiring = registryFactory.create(this.typesByService);
         this.braid = Braid.builder()
                 .executionStrategy(asyncExecutionStrategy)
-                .typeDefinitionRegistry(registryFactory.create(this.typesByService))
+                .typeDefinitionRegistry(typesWithWiring.typeDefinitionRegistry())
+                .withRuntimeWiring(builder -> typesWithWiring.typeRuntimeWirings().forEach(builder::type))
                 .schemaSources(schemaSources)
                 .build();
     }

--- a/src/main/java/graphql/nadel/TypeDefinitionRegistryFactory.java
+++ b/src/main/java/graphql/nadel/TypeDefinitionRegistryFactory.java
@@ -4,20 +4,22 @@ import graphql.schema.idl.TypeDefinitionRegistry;
 
 import java.util.Map;
 
+import static graphql.nadel.TypeDefinitionsWithRuntimeWiring.newTypeDefinitionWithRuntimeWiring;
+
 /**
- * Factory that creates {@link TypeDefinitionRegistry} that will be added to a stitched schema.
+ * Factory that provides {@link TypeDefinitionsWithRuntimeWiring} to be added to a stitched schema.
  */
 public interface TypeDefinitionRegistryFactory {
     TypeDefinitionRegistryFactory DEFAULT = (Map<String, TypeDefinitionRegistry> serviceTypeDefinitions) ->
-            new TypeDefinitionRegistry();
+            newTypeDefinitionWithRuntimeWiring().build();
 
     /**
-     * Creates {@link TypeDefinitionRegistry}.
+     * Creates {@link TypeDefinitionsWithRuntimeWiring} that might be based on existing types defined in DSL.
      *
      * @param serviceTypeDefinitions map containing  {@link TypeDefinitionRegistry} (as a value) for each service name
      *                               (key) defined in Nadel DSL. May be used to add new types based on directives etc.
      *
-     * @return type definition that will be added to a stitched schema, cannot be null.
+     * @return type definitions and runtime wirings that will be added to a stitched schema, cannot be null.
      */
-    TypeDefinitionRegistry create(Map<String, TypeDefinitionRegistry> serviceTypeDefinitions);
+    TypeDefinitionsWithRuntimeWiring create(Map<String, TypeDefinitionRegistry> serviceTypeDefinitions);
 }

--- a/src/main/java/graphql/nadel/TypeDefinitionsWithRuntimeWiring.java
+++ b/src/main/java/graphql/nadel/TypeDefinitionsWithRuntimeWiring.java
@@ -1,0 +1,56 @@
+package graphql.nadel;
+
+import graphql.schema.idl.TypeDefinitionRegistry;
+import graphql.schema.idl.TypeRuntimeWiring;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Stores {@link TypeDefinitionRegistry} and collection of {@link TypeRuntimeWiring}s.
+ */
+public class TypeDefinitionsWithRuntimeWiring {
+    private final TypeDefinitionRegistry typeDefinitionRegistry;
+    private final List<TypeRuntimeWiring> typeRuntimeWirings;
+
+    private TypeDefinitionsWithRuntimeWiring(TypeDefinitionRegistry typeDefinitionRegistry,
+                                             List<TypeRuntimeWiring> typeRuntimeWirings) {
+        this.typeDefinitionRegistry = typeDefinitionRegistry;
+        this.typeRuntimeWirings = typeRuntimeWirings;
+    }
+
+    public static Builder newTypeDefinitionWithRuntimeWiring() {
+        return new Builder();
+    }
+
+    public TypeDefinitionRegistry typeDefinitionRegistry() {
+        return typeDefinitionRegistry;
+    }
+
+    public List<TypeRuntimeWiring> typeRuntimeWirings() {
+        return typeRuntimeWirings;
+    }
+
+    public static class Builder {
+        private TypeDefinitionRegistry typeDefinitionRegistry = new TypeDefinitionRegistry();
+        private List<TypeRuntimeWiring> typeRuntimeWirings = new ArrayList<>();
+
+        private Builder() {
+        }
+
+        public Builder withTypeDefinitionRegistry(TypeDefinitionRegistry registry) {
+            this.typeDefinitionRegistry = Objects.requireNonNull(registry, "registry");
+            return this;
+        }
+
+        public Builder withTypeRuntimeWiring(TypeRuntimeWiring wiring) {
+            this.typeRuntimeWirings.add(Objects.requireNonNull(wiring, "wiring"));
+            return this;
+        }
+
+        public TypeDefinitionsWithRuntimeWiring build() {
+            return new TypeDefinitionsWithRuntimeWiring(this.typeDefinitionRegistry, this.typeRuntimeWirings);
+        }
+    }
+}


### PR DESCRIPTION
I forgot in the last PR that TypeDefinitionRegistry itself is not enough to provide data fetchers. This PR fixes that and also adds test.