### PR TITLE
Update Braid to latest version with type rename support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ targetCompatibility = 1.8
 
 def slf4jVersion = '1.7.25'
 def graphqlJavaVersion = '10.0'
-def braidVersion = '0.17.0'
+def braidVersion = '0.17.2-SNAPSHOT'
 
 def releaseVersion = System.env.RELEASE_VERSION
 version = releaseVersion ? releaseVersion : getDevelopmentVersion()

--- a/src/main/java/graphql/nadel/GraphQLRemoteSchemaSourceFactory.java
+++ b/src/main/java/graphql/nadel/GraphQLRemoteSchemaSourceFactory.java
@@ -3,6 +3,7 @@ package graphql.nadel;
 import com.atlassian.braid.Link;
 import com.atlassian.braid.SchemaNamespace;
 import com.atlassian.braid.SchemaSource;
+import com.atlassian.braid.TypeRename;
 import com.atlassian.braid.document.DocumentMapperFactory;
 import com.atlassian.braid.document.DocumentMappers;
 import com.atlassian.braid.document.TypeMapper;
@@ -31,7 +32,7 @@ class GraphQLRemoteSchemaSourceFactory<C> implements SchemaSourceFactory {
     @Override
     public SchemaSource createSchemaSource(ServiceDefinition definition, SchemaNamespace namespace,
                                            TypeDefinitionRegistry typeDefinitionRegistry, List<Link> links,
-                                           List<TypeMapper> mappers) {
+                                           List<TypeMapper> mappers, List<TypeRename> typeRenames) {
         DocumentMapperFactory factory = DocumentMappers.identity();
         for (TypeMapper mapper : mappers) {
             factory = factory.mapType(mapper);
@@ -43,7 +44,7 @@ class GraphQLRemoteSchemaSourceFactory<C> implements SchemaSourceFactory {
                 links,
                 emptyList(),
                 factory,
-                emptyList(),
+                typeRenames,
                 emptyList(),
                 emptyList());
     }

--- a/src/main/java/graphql/nadel/SchemaSourceFactory.java
+++ b/src/main/java/graphql/nadel/SchemaSourceFactory.java
@@ -4,6 +4,7 @@ package graphql.nadel;
 import com.atlassian.braid.Link;
 import com.atlassian.braid.SchemaNamespace;
 import com.atlassian.braid.SchemaSource;
+import com.atlassian.braid.TypeRename;
 import com.atlassian.braid.document.TypeMapper;
 import graphql.nadel.dsl.ServiceDefinition;
 import graphql.schema.idl.TypeDefinitionRegistry;
@@ -16,5 +17,5 @@ import java.util.List;
 public interface SchemaSourceFactory {
     SchemaSource createSchemaSource(ServiceDefinition definition, SchemaNamespace namespace,
                                     TypeDefinitionRegistry typeDefinitionRegistry, List<Link> links,
-                                    List<TypeMapper> mappers);
+                                    List<TypeMapper> mappers, List<TypeRename> typeRenames);
 }

--- a/src/test/groovy/graphql/nadel/NadelTest.groovy
+++ b/src/test/groovy/graphql/nadel/NadelTest.groovy
@@ -4,7 +4,6 @@ import com.atlassian.braid.source.GraphQLRemoteRetriever
 import com.atlassian.braid.transformation.SchemaTransformation
 import graphql.ExecutionInput
 import graphql.GraphQL
-import graphql.language.TypeName
 import graphql.nadel.dsl.ServiceDefinition
 import graphql.schema.DataFetcher
 import graphql.schema.GraphQLSchema
@@ -16,8 +15,6 @@ import graphql.schema.idl.TypeDefinitionRegistry
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import static graphql.language.FieldDefinition.newFieldDefinition
-import static graphql.language.ObjectTypeDefinition.newObjectTypeDefinition
 import static graphql.schema.idl.RuntimeWiring.newRuntimeWiring
 import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring
 import static java.util.concurrent.CompletableFuture.completedFuture
@@ -168,6 +165,48 @@ class NadelTest extends Specification {
         "simple"          | "{foo { newName newTitle barId }}"                               | _
         "inline fragment" | "{foo {... on Foo { newName  barId newTitle} }} "                | _
         "named fragment"  | "fragment cf on Foo { newName  barId newTitle} {foo { ... cf}} " | _
+    }
+
+    @Unroll
+    def "stitching with #fragment type rename"(String fragment, String query) {
+        def dsl = """
+            service FooService {
+                schema {
+                    query: Query
+                }
+                type Query {
+                    foo: [Foo2!]
+                }
+    
+                type Foo2 <= \$innerTypes.Foo {
+                    newName: ID <= \$source.id
+                    barId: ID
+                    newTitle : String <=\$source.title
+                    name: String   
+                }
+            }
+        """
+
+        def fooService = fooService([new Foo("foo1", "name1", "title1", "someBarId1"),
+                                     new Foo("foo2", "name2", "title2", "someBarId2")])
+        GraphQLRemoteRetriever graphqlRemoteRetrieverFoo = { input, ctx ->
+            return completedFuture([data: (Map<String, Object>) fooService.execute(input).getData()])
+        }
+        def callerFactory = mockCallerFactory([FooService: graphqlRemoteRetrieverFoo])
+
+        Nadel nadel = new Nadel(dsl, callerFactory)
+        when:
+        def executionResult = nadel.executeAsync(ExecutionInput.newExecutionInput().query(query).build()).get()
+
+        then:
+        executionResult.data == [foo: [[newName: 'foo1', barId: 'someBarId1', newTitle: 'title1'],
+                                       [newName: 'foo2', barId: 'someBarId2', newTitle: 'title2']]]
+
+        where:
+        fragment          | query                                                             | _
+        "simple"          | "{foo { newName newTitle barId }}"                                | _
+//      "inline fragment" | " {f1: foo {... on Foo2 { newName  barId newTitle} } } "         | _
+        "named fragment"  | "fragment cf on Foo2 { newName  barId newTitle} {foo { ... cf}} " | _
     }
 
     def "additional runtime wiring provided programmatically"() {


### PR DESCRIPTION
Update Braid to 0.17.2-snapshot with type rename support for named fragment. 