### PR TITLE
Referenced variables to transformed query

### DIFF
--- a/src/main/java/graphql/nadel/FpKit.java
+++ b/src/main/java/graphql/nadel/FpKit.java
@@ -1,6 +1,7 @@
 package graphql.nadel;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
@@ -8,6 +9,10 @@ import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 public class FpKit {
+
+    public static <T> Map<String, T> getByName(List<T> namedObjects, Function<T, String> nameFn) {
+        return graphql.util.FpKit.getByName(namedObjects, nameFn);
+    }
 
     public static <T, K, U> Collector<T, ?, Map<K, U>> toMapCollector(Function<? super T, ? extends K> keyMapper,
                                                                       Function<? super T, ? extends U> valueMapper) {

--- a/src/main/java/graphql/nadel/engine/QueryTransformationResult.java
+++ b/src/main/java/graphql/nadel/engine/QueryTransformationResult.java
@@ -3,6 +3,7 @@ package graphql.nadel.engine;
 import graphql.execution.MergedField;
 import graphql.language.Document;
 import graphql.language.Field;
+import graphql.language.FragmentDefinition;
 import graphql.nadel.engine.transformation.FieldTransformation;
 
 import java.util.List;
@@ -13,15 +14,24 @@ public class QueryTransformationResult {
     private final Document document;
 
     private final List<MergedField> transformedMergedFields;
+    private final List<String> referencedVariables;
     private final Field transformedField;
 
     private final Map<Field, FieldTransformation> transformationByResultField;
+    private final Map<String, FragmentDefinition> transformedFragments;
 
-    public QueryTransformationResult(Document document, List<MergedField> transformedMergedFields, Field transformedField, Map<Field, FieldTransformation> transformationByResultField) {
+    public QueryTransformationResult(Document document,
+                                     List<MergedField> transformedMergedFields,
+                                     List<String> referencedVariables,
+                                     Field transformedField,
+                                     Map<Field, FieldTransformation> transformationByResultField,
+                                     Map<String, FragmentDefinition> transformedFragments) {
         this.document = document;
         this.transformedMergedFields = transformedMergedFields;
+        this.referencedVariables = referencedVariables;
         this.transformedField = transformedField;
         this.transformationByResultField = transformationByResultField;
+        this.transformedFragments = transformedFragments;
     }
 
     public Document getDocument() {
@@ -32,12 +42,20 @@ public class QueryTransformationResult {
         return transformedMergedFields;
     }
 
+    public List<String> getReferencedVariables() {
+        return referencedVariables;
+    }
+
     public Field getTransformedField() {
         return transformedField;
     }
 
     public Map<Field, FieldTransformation> getTransformationByResultField() {
         return transformationByResultField;
+    }
+
+    public Map<String, FragmentDefinition> getTransformedFragments() {
+        return transformedFragments;
     }
 }
 

--- a/src/main/java/graphql/nadel/engine/ServiceResultToResultNodes.java
+++ b/src/main/java/graphql/nadel/engine/ServiceResultToResultNodes.java
@@ -15,9 +15,7 @@ import graphql.execution.nextgen.result.NamedResultNode;
 import graphql.execution.nextgen.result.ObjectExecutionResultNode;
 import graphql.execution.nextgen.result.ResultNodesUtil;
 import graphql.execution.nextgen.result.RootExecutionResultNode;
-import graphql.nadel.Operation;
 import graphql.nadel.ServiceExecutionResult;
-import graphql.schema.GraphQLSchema;
 import graphql.util.FpKit;
 import graphql.util.NodeMultiZipper;
 import graphql.util.NodeZipper;
@@ -36,28 +34,21 @@ public class ServiceResultToResultNodes {
     ExecutionStrategyUtil util = new ExecutionStrategyUtil();
 
     public RootExecutionResultNode resultToResultNode(ExecutionContext executionContext,
-                                                      ServiceExecutionResult serviceExecutionResult,
                                                       ExecutionStepInfo executionStepInfo,
                                                       List<MergedField> mergedFields,
-                                                      GraphQLSchema underlyingSchema,
-                                                      Operation operation) {
-
-        //TODO: currently changing the ExecutionContext and stepInfo so that it fits the underlying schema, this should be done somewhere else
-        ExecutionContext executionContextForService = executionContext.transform(builder -> builder.graphQLSchema(underlyingSchema));
-        ExecutionStepInfo stepInfoForService = executionStepInfo.transform(builder -> builder.type(operation.getRootType(underlyingSchema)));
-
+                                                      ServiceExecutionResult serviceExecutionResult) {
 
         Map<String, MergedField> subFields = FpKit.getByName(mergedFields, MergedField::getResultKey);
         MergedSelectionSet mergedSelectionSet = MergedSelectionSet.newMergedSelectionSet()
                 .subFields(subFields).build();
 
         FieldSubSelection fieldSubSelectionWithData = FieldSubSelection.newFieldSubSelection().
-                executionInfo(stepInfoForService)
+                executionInfo(executionStepInfo)
                 .source(serviceExecutionResult.getData())
                 .mergedSelectionSet(mergedSelectionSet)
                 .build();
 
-        List<ExecutionResultNode> namedResultNodes = resolveSubSelection(executionContextForService, fieldSubSelectionWithData);
+        List<ExecutionResultNode> namedResultNodes = resolveSubSelection(executionContext, fieldSubSelectionWithData);
         return new RootExecutionResultNode(namedResultNodes);
     }
 

--- a/src/test/groovy/graphql/nadel/engine/OverallQueryTransformerTest.groovy
+++ b/src/test/groovy/graphql/nadel/engine/OverallQueryTransformerTest.groovy
@@ -108,6 +108,24 @@ class OverallQueryTransformerTest extends Specification {
                 'query {f1:foo(id:"1") {...frag1} f2:foo(id:"2") {...frag2}} fragment frag1 on Foo {id} fragment frag2 on Foo {id bazId}'
     }
 
+    def "used variables are included and not used ones left out"() {
+        def query = TestUtil.parseQuery(
+                '''query( $usedVariable : String, $unusedVariable : String )
+            {
+               foo(id : $usedVariable) {
+                 id
+               }
+            }
+            ''')
+
+        when:
+        def delegateQuery = doTransform(schema, query)
+
+        then:
+        AstPrinter.printAstCompact(delegateQuery) ==
+                'query ($usedVariable:String) {foo(id:$usedVariable) {id}}'
+    }
+
     def "nested fragments are transformed and included"() {
         def query = TestUtil.parseQuery(
                 '''

--- a/src/test/groovy/graphql/nadel/engine/ServiceResultToResultNodesTest.groovy
+++ b/src/test/groovy/graphql/nadel/engine/ServiceResultToResultNodesTest.groovy
@@ -3,7 +3,6 @@ package graphql.nadel.engine
 import graphql.execution.ExecutionContext
 import graphql.execution.nextgen.FieldSubSelection
 import graphql.execution.nextgen.result.ResultNodesUtil
-import graphql.nadel.Operation
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.TestUtil
 import spock.lang.Specification
@@ -25,11 +24,10 @@ class ServiceResultToResultNodesTest extends Specification {
 
         when:
         def node = resultToNodes.resultToResultNode(executionContext,
-                delegatedResult,
                 fieldSubSelection.getExecutionStepInfo(),
                 fieldSubSelection.getMergedSelectionSet().getSubFieldsList(),
-                schema,
-                Operation.QUERY)
+                delegatedResult
+        )
         def executionResult = ResultNodesUtil.toExecutionResult(node)
 
         then:
@@ -52,11 +50,10 @@ class ServiceResultToResultNodesTest extends Specification {
 
         when:
         def node = resultToNodes.resultToResultNode(executionContext,
-                delegatedResult,
                 fieldSubSelection.getExecutionStepInfo(),
                 fieldSubSelection.getMergedSelectionSet().getSubFieldsList(),
-                schema,
-                Operation.QUERY)
+                delegatedResult
+        )
         def executionResult = ResultNodesUtil.toExecutionResult(node)
 
         then:
@@ -103,11 +100,10 @@ class ServiceResultToResultNodesTest extends Specification {
 
         when:
         def node = resultToNodes.resultToResultNode(executionContext,
-                delegatedResult,
                 fieldSubSelection.getExecutionStepInfo(),
                 fieldSubSelection.getMergedSelectionSet().getSubFieldsList(),
-                schema,
-                Operation.QUERY)
+                delegatedResult
+        )
         def executionResult = ResultNodesUtil.toExecutionResult(node)
 
         then:
@@ -129,11 +125,10 @@ class ServiceResultToResultNodesTest extends Specification {
 
         when:
         def node = resultToNodes.resultToResultNode(executionContext,
-                delegatedResult,
                 fieldSubSelection.getExecutionStepInfo(),
                 fieldSubSelection.getMergedSelectionSet().getSubFieldsList(),
-                schema,
-                Operation.QUERY)
+                delegatedResult
+        )
         def executionResult = ResultNodesUtil.toExecutionResult(node)
 
         then:
@@ -155,11 +150,10 @@ class ServiceResultToResultNodesTest extends Specification {
 
         when:
         def node = resultToNodes.resultToResultNode(executionContext,
-                delegatedResult,
                 fieldSubSelection.getExecutionStepInfo(),
                 fieldSubSelection.getMergedSelectionSet().getSubFieldsList(),
-                schema,
-                Operation.QUERY)
+                delegatedResult
+        )
         def executionResult = ResultNodesUtil.toExecutionResult(node)
 
         then:
@@ -181,11 +175,10 @@ class ServiceResultToResultNodesTest extends Specification {
 
         when:
         def node = resultToNodes.resultToResultNode(executionContext,
-                delegatedResult,
                 fieldSubSelection.getExecutionStepInfo(),
                 fieldSubSelection.getMergedSelectionSet().getSubFieldsList(),
-                schema,
-                Operation.QUERY)
+                delegatedResult
+        )
         def executionResult = ResultNodesUtil.toExecutionResult(node)
 
         then:
@@ -207,11 +200,10 @@ class ServiceResultToResultNodesTest extends Specification {
 
         when:
         def node = resultToNodes.resultToResultNode(executionContext,
-                delegatedResult,
                 fieldSubSelection.getExecutionStepInfo(),
                 fieldSubSelection.getMergedSelectionSet().getSubFieldsList(),
-                schema,
-                Operation.QUERY)
+                delegatedResult
+        )
         def executionResult = ResultNodesUtil.toExecutionResult(node)
 
         then:


### PR DESCRIPTION
Sorry that there is a fair bit of refactoring here - some of the code got moved around to make it better

This adds the ability to call downstream services with ONLY referenced variables AND fragments and then have the results mapped (and hydrated) back into the result nodes