### PR TITLE
Now with wordy syntax in nadel 

### DIFF
--- a/src/main/antlr/StitchingDSL.g4
+++ b/src/main/antlr/StitchingDSL.g4
@@ -5,31 +5,35 @@ import GraphqlSDL;
     package graphql.nadel.parser.antlr;
 }
 
-stitchingDSL: serviceDefinition+;
+stitchingDSL:
+   serviceDefinition+;
 
 serviceDefinition:
-'service' name '{' typeSystemDefinition* '}' ;
+   'service' name '{' typeSystemDefinition* '}' ;
 
 objectTypeDefinition : description? TYPE name implementsInterfaces? typeTransformation? directives? fieldsDefinition? ;
 
 fieldDefinition : description? name argumentsDefinition? ':' type directives? fieldTransformation?;
 
-fieldTransformation : '<=' (fieldMappingDefinition | innerServiceHydration);
+fieldTransformation : '=>' (fieldMappingDefinition | innerServiceHydration);
 
-typeTransformation : '<=' '$innerTypes' '.' name;
+typeTransformation : '=>' typeMappingDefinition;
 
-fieldMappingDefinition : '$source' '.' name ;
+//
+// renames
+//
+typeMappingDefinition : 'renamed as' name;
 
-innerServiceHydration: '$innerQueries' '.' serviceName '.' topLevelField remoteCallDefinition? objectIdentifier? batchSize?;
+fieldMappingDefinition : 'renamed as' name;
+
+//
+// hydration
+
+innerServiceHydration: 'hydrated as' serviceName '.' topLevelField remoteCallDefinition? objectIdentifier? batchSize?;
 
 objectIdentifier: 'object identified by' name;
+
 batchSize: 'batch size ' intValue;
-
-intValue: IntValue;
-
-serviceName: NAME;
-
-topLevelField: NAME;
 
 remoteArgumentSource :  sourceObjectReference | fieldArgumentReference | contextArgumentReference;
 
@@ -44,4 +48,8 @@ fieldArgumentReference : '$argument' '.' name ;
 
 contextArgumentReference : '$context' '.' name ;
 
+intValue: IntValue;
 
+serviceName: NAME;
+
+topLevelField: NAME;

--- a/src/main/java/graphql/nadel/NadelAntlrToLanguage.java
+++ b/src/main/java/graphql/nadel/NadelAntlrToLanguage.java
@@ -13,7 +13,7 @@ import graphql.nadel.dsl.RemoteArgumentDefinition;
 import graphql.nadel.dsl.RemoteArgumentSource;
 import graphql.nadel.dsl.ServiceDefinition;
 import graphql.nadel.dsl.StitchingDsl;
-import graphql.nadel.dsl.TypeTransformation;
+import graphql.nadel.dsl.TypeMappingDefinition;
 import graphql.nadel.parser.GraphqlAntlrToLanguage;
 import graphql.nadel.parser.antlr.StitchingDSLParser;
 import graphql.parser.MultiSourceReader;
@@ -114,11 +114,11 @@ public class NadelAntlrToLanguage extends GraphqlAntlrToLanguage {
         if (ctx.typeTransformation() == null) {
             return objectTypeDefinition;
         }
-        TypeTransformation typeTransformation = new TypeTransformation(null, new ArrayList<>());
-        typeTransformation.setUnderlyingName(ctx.typeTransformation().name().getText());
-        typeTransformation.setOverallName(ctx.name().getText());
+        TypeMappingDefinition typeMappingDefinition = new TypeMappingDefinition(null, new ArrayList<>());
+        typeMappingDefinition.setUnderlyingName(ctx.typeTransformation().typeMappingDefinition().name().getText());
+        typeMappingDefinition.setOverallName(ctx.name().getText());
         return ObjectTypeDefinitionWithTransformation.newObjectTypeDefinitionWithTransformation(objectTypeDefinition)
-                .typeTransformation(typeTransformation)
+                .typeMappingDefinition(typeMappingDefinition)
                 .build();
     }
 

--- a/src/main/java/graphql/nadel/dsl/ObjectTypeDefinitionWithTransformation.java
+++ b/src/main/java/graphql/nadel/dsl/ObjectTypeDefinitionWithTransformation.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 public class ObjectTypeDefinitionWithTransformation extends ObjectTypeDefinition {
 
-    private final TypeTransformation typeTransformation;
+    private final TypeMappingDefinition typeMappingDefinition;
 
     protected ObjectTypeDefinitionWithTransformation(String name,
                                                      List<Type> implementz,
@@ -24,13 +24,13 @@ public class ObjectTypeDefinitionWithTransformation extends ObjectTypeDefinition
                                                      Description description,
                                                      SourceLocation sourceLocation,
                                                      List<Comment> comments,
-                                                     TypeTransformation typeTransformation, IgnoredChars ignoredChars) {
+                                                     TypeMappingDefinition typeMappingDefinition, IgnoredChars ignoredChars) {
         super(name, implementz, directives, fieldDefinitions, description, sourceLocation, comments, ignoredChars);
-        this.typeTransformation = typeTransformation;
+        this.typeMappingDefinition = typeMappingDefinition;
     }
 
-    public TypeTransformation getTypeTransformation() {
-        return typeTransformation;
+    public TypeMappingDefinition getTypeMappingDefinition() {
+        return typeMappingDefinition;
     }
 
     public static ObjectTypeDefinitionWithTransformation.Builder newObjectTypeDefinitionWithTransformation(ObjectTypeDefinition copyFrom) {
@@ -45,7 +45,7 @@ public class ObjectTypeDefinitionWithTransformation extends ObjectTypeDefinition
         private List<Type> implementz = new ArrayList<>();
         private List<Directive> directives = new ArrayList<>();
         private List<FieldDefinition> fieldDefinitions = new ArrayList<>();
-        private TypeTransformation typeTransformation;
+        private TypeMappingDefinition typeMappingDefinition;
         private IgnoredChars ignoredChars = IgnoredChars.EMPTY;
 
         private Builder() {
@@ -61,8 +61,8 @@ public class ObjectTypeDefinitionWithTransformation extends ObjectTypeDefinition
             this.fieldDefinitions = existing.getFieldDefinitions();
         }
 
-        public Builder typeTransformation(TypeTransformation typeTransformation) {
-            this.typeTransformation = typeTransformation;
+        public Builder typeMappingDefinition(TypeMappingDefinition typeMappingDefinition) {
+            this.typeMappingDefinition = typeMappingDefinition;
             return this;
         }
 
@@ -123,15 +123,15 @@ public class ObjectTypeDefinitionWithTransformation extends ObjectTypeDefinition
         }
 
         public ObjectTypeDefinitionWithTransformation build() {
-            ObjectTypeDefinitionWithTransformation objectTypeDefinition = new ObjectTypeDefinitionWithTransformation(name,
+            return new ObjectTypeDefinitionWithTransformation(name,
                     implementz,
                     directives,
                     fieldDefinitions,
                     description,
                     sourceLocation,
                     comments,
-                    typeTransformation, ignoredChars);
-            return objectTypeDefinition;
+                    typeMappingDefinition,
+                    ignoredChars);
         }
     }
 }

--- a/src/main/java/graphql/nadel/dsl/TypeMappingDefinition.java
+++ b/src/main/java/graphql/nadel/dsl/TypeMappingDefinition.java
@@ -12,13 +12,13 @@ import graphql.util.TraverserContext;
 
 import java.util.List;
 
-public class TypeTransformation extends AbstractNode<TypeTransformation> {
+public class TypeMappingDefinition extends AbstractNode<TypeMappingDefinition> {
 
     private String underlyingName;
     private String overallName;
 
 
-    public TypeTransformation(SourceLocation sourceLocation, List<Comment> comments) {
+    public TypeMappingDefinition(SourceLocation sourceLocation, List<Comment> comments) {
         super(sourceLocation, comments, IgnoredChars.EMPTY);
     }
 
@@ -49,7 +49,7 @@ public class TypeTransformation extends AbstractNode<TypeTransformation> {
     }
 
     @Override
-    public TypeTransformation withNewChildren(NodeChildrenContainer newChildren) {
+    public TypeMappingDefinition withNewChildren(NodeChildrenContainer newChildren) {
         return null;
     }
 
@@ -59,7 +59,7 @@ public class TypeTransformation extends AbstractNode<TypeTransformation> {
     }
 
     @Override
-    public TypeTransformation deepCopy() {
+    public TypeMappingDefinition deepCopy() {
         return null;
     }
 

--- a/src/test/groovy/graphql/nadel/NSDLParserTest.groovy
+++ b/src/test/groovy/graphql/nadel/NSDLParserTest.groovy
@@ -89,7 +89,7 @@ class NSDLParserTest extends Specification {
             }
 
             type Foo {
-                id: ID <= \$source.fooId
+                id: ID => renamed as fooId
             }
         }
         """
@@ -114,7 +114,7 @@ class NSDLParserTest extends Specification {
             }
 
             type Foo {
-                id(inputArg: ID!): ID <= $innerQueries.OtherService.resolveId(otherId: $source.id, 
+                id(inputArg: ID!): ID => hydrated as OtherService.resolveId(otherId: $source.id, 
                 arg1: $context.ctxParam, arg2: $argument.inputArg)
             }
         }
@@ -136,7 +136,7 @@ class NSDLParserTest extends Specification {
                     foo: Foo
                 }
 
-                type Foo <= \$innerTypes.OriginalFooName {
+                type Foo => renamed as OriginalFooName {
                     id: ID
                 }
             }
@@ -159,13 +159,13 @@ class NSDLParserTest extends Specification {
                 }
 
                 type Foo {
-                    newId: ID <= \$source.id @testdirective 
+                    newId: ID > renamed as id @testdirective 
                 }
             }
         """
         when:
         NSDLParser parser = new NSDLParser()
-        def stitchingDSL = parser.parseDSL(dsl)
+        parser.parseDSL(dsl)
         then:
         thrown(Exception)
     }
@@ -181,7 +181,7 @@ class NSDLParserTest extends Specification {
                 }
 
                 type Foo {
-                    newId: ID @testdirective  <= \$source.id 
+                    newId: ID @testdirective  => renamed as id 
                 }
             }
         """

--- a/src/test/groovy/graphql/nadel/NadelE2ETest.groovy
+++ b/src/test/groovy/graphql/nadel/NadelE2ETest.groovy
@@ -107,7 +107,7 @@ class NadelE2ETest extends Specification {
         def nsdl = '''
          service Foo {
             type Query{
-                foo: Foo  <= \$source.fooOriginal 
+                foo: Foo  => renamed as fooOriginal 
             } 
             type Foo {
                 name: String
@@ -118,7 +118,7 @@ class NadelE2ETest extends Specification {
                 bar: Bar 
             } 
             type Bar {
-                name: String <= \$source.title
+                name: String => renamed as title
             }
          }
         '''
@@ -180,7 +180,7 @@ class NadelE2ETest extends Specification {
             } 
             type Foo {
                 name: String
-                bar: Bar <= \$innerQueries.Bar.barsById(id: \$source.barId) object identified by barId, batch size 2
+                bar: Bar => hydrated as Bar.barsById(id: $source.barId) object identified by barId, batch size 2
             }
          }
          service Bar {
@@ -190,7 +190,7 @@ class NadelE2ETest extends Specification {
             type Bar {
                 barId: ID
                 name: String 
-                nestedBar: Bar <= \$innerQueries.Bar.barsById(id: \$source.nestedBarId) object identified by barId
+                nestedBar: Bar => hydrated as Bar.barsById(id: $source.nestedBarId) object identified by barId
             }
          }
         '''

--- a/src/test/groovy/graphql/nadel/NadelErrorHandlingTest.groovy
+++ b/src/test/groovy/graphql/nadel/NadelErrorHandlingTest.groovy
@@ -108,7 +108,7 @@ class NadelErrorHandlingTest extends Specification {
             } 
             type Foo {
                 name: String
-                bar: Bar <= \$innerQueries.Bar.barById(id: \$source.barId)
+                bar: Bar => hydrated as Bar.barById(id: $source.barId)
             }
          }
          service Bar {
@@ -117,7 +117,7 @@ class NadelErrorHandlingTest extends Specification {
             } 
             type Bar {
                 name: String 
-                nestedBar: Bar <= \$innerQueries.Bar.barById(id: \$source.nestedBarId)
+                nestedBar: Bar => hydrated as Bar.barById(id: $source.nestedBarId)
             }
          }
         '''

--- a/src/test/groovy/graphql/nadel/NadelInterfaceAndUnionHandlingTest.groovy
+++ b/src/test/groovy/graphql/nadel/NadelInterfaceAndUnionHandlingTest.groovy
@@ -26,7 +26,7 @@ class NadelInterfaceAndUnionHandlingTest extends Specification {
             
             interface Pet {
                 name : String
-                owners: [Owner] <= $innerQueries.OwnerService.ownerById(id: $source.ownerIds)
+                owners: [Owner] => hydrated as OwnerService.ownerById(id: $source.ownerIds)
             }
             
             type Cat implements Pet {

--- a/src/test/groovy/graphql/nadel/NadelRenameTest.groovy
+++ b/src/test/groovy/graphql/nadel/NadelRenameTest.groovy
@@ -15,13 +15,13 @@ class NadelRenameTest extends Specification {
          service MyService {
             type Query{
                 hello: World  
-                renameOverall : RenameOverall <= $source.renameUnderlying   # the field is renamed 
+                renameOverall : RenameOverall => renamed as renameUnderlying   # the field is renamed 
             } 
             type World {
                 id: ID
                 name: String
             }
-            type RenameOverall <= $innerTypes.RenameUnderlying {  # and the type is renamed
+            type RenameOverall => renamed as RenameUnderlying {  # and the type is renamed
                 name : String
             }
          }

--- a/src/test/groovy/graphql/nadel/engine/NadelExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/nadel/engine/NadelExecutionStrategyTest.groovy
@@ -145,14 +145,14 @@ class NadelExecutionStrategyTest extends Specification {
         }
         """)
 
-    def overallHydrationSchema = TestUtil.schemaFromNdsl("""
+    def overallHydrationSchema = TestUtil.schemaFromNdsl('''
         service service1 {
             type Query {
                 foo(id : ID): Foo
             }
             type Foo {
                 id: ID
-                bar: Bar <= \$innerQueries.service2.barById(id: \$source.barId)
+                bar: Bar => hydrated as service2.barById(id: $source.barId)
             }
         }
         service service2 {
@@ -164,7 +164,7 @@ class NadelExecutionStrategyTest extends Specification {
                 name: String
             }
         }
-        """)
+        ''')
 
 
     def "one hydration call with variables defined"() {
@@ -274,14 +274,14 @@ class NadelExecutionStrategyTest extends Specification {
         }
         """)
 
-        def overallSchema = TestUtil.schemaFromNdsl("""
+        def overallSchema = TestUtil.schemaFromNdsl('''
         service service1 {
             type Query {
                 foo: Foo
             }
             type Foo {
                 id: ID
-                bar: [Bar] <= \$innerQueries.service2.barById(id: \$source.barId)
+                bar: [Bar] => hydrated as service2.barById(id: $source.barId)
             }
         }
         service service2 {
@@ -293,7 +293,7 @@ class NadelExecutionStrategyTest extends Specification {
                 name: String
             }
         }
-        """)
+        ''')
         def fooFieldDefinition = overallSchema.getQueryType().getFieldDefinition("foo")
 
         def service1 = new Service("service1", underlyingSchema1, service1Execution, serviceDefinition, definitionRegistry)
@@ -361,14 +361,14 @@ class NadelExecutionStrategyTest extends Specification {
         }
         """)
 
-        def overallSchema = TestUtil.schemaFromNdsl("""
+        def overallSchema = TestUtil.schemaFromNdsl('''
         service service1 {
             type Query {
                 foo: Foo
             }
             type Foo {
                 id: ID
-                bar: [Bar] <= \$innerQueries.service2.barsById(id: \$source.barId)
+                bar: [Bar] => hydrated as service2.barsById(id: $source.barId)
             }
         }
         service service2 {
@@ -380,7 +380,7 @@ class NadelExecutionStrategyTest extends Specification {
                 name: String
             }
         }
-        """)
+        ''')
         def fooFieldDefinition = overallSchema.getQueryType().getFieldDefinition("foo")
 
         def service1 = new Service("service1", underlyingSchema1, service1Execution, serviceDefinition, definitionRegistry)
@@ -436,14 +436,14 @@ class NadelExecutionStrategyTest extends Specification {
         }
         """)
 
-        def overallSchema = TestUtil.schemaFromNdsl("""
+        def overallSchema = TestUtil.schemaFromNdsl('''
         service service1 {
             type Query {
                 foo: Foo
             }
             type Foo {
                 id: ID
-                bar: [Bar] <= \$innerQueries.service2.barsById(id: \$source.barId)
+                bar: [Bar] => hydrated as service2.barsById(id: $source.barId)
             }
         }
         service service2 {
@@ -455,7 +455,7 @@ class NadelExecutionStrategyTest extends Specification {
                 name: String
             }
         }
-        """)
+        ''')
         def fooFieldDefinition = overallSchema.getQueryType().getFieldDefinition("foo")
 
         def service1 = new Service("service1", underlyingSchema1, service1Execution, serviceDefinition, definitionRegistry)
@@ -511,14 +511,14 @@ class NadelExecutionStrategyTest extends Specification {
         }
         """)
 
-        def overallSchema = TestUtil.schemaFromNdsl("""
+        def overallSchema = TestUtil.schemaFromNdsl('''
         service service1 {
             type Query {
                 foo: Foo
             }
             type Foo {
                 id: ID
-                bar: [Bar] <= \$innerQueries.service2.barById(id: \$source.barId)
+                bar: [Bar] => hydrated as service2.barById(id: $source.barId)
             }
         }
         service service2 {
@@ -530,7 +530,7 @@ class NadelExecutionStrategyTest extends Specification {
                 name: String
             }
         }
-        """)
+        ''')
         def fooFieldDefinition = overallSchema.getQueryType().getFieldDefinition("foo")
 
         def service1 = new Service("service1", underlyingSchema1, service1Execution, serviceDefinition, definitionRegistry)

--- a/src/test/groovy/graphql/nadel/engine/OverallQueryTransformerTest.groovy
+++ b/src/test/groovy/graphql/nadel/engine/OverallQueryTransformerTest.groovy
@@ -14,7 +14,7 @@ class OverallQueryTransformerTest extends Specification {
     def schema = TestUtil.schemaFromNdsl('''
         service example {
             type Query { 
-                hello: String <= $source.helloWorld 
+                hello: String => renamed as helloWorld 
                 foo(id: ID!): Foo
                 bar(id: ID!): Bar
             }
@@ -24,12 +24,12 @@ class OverallQueryTransformerTest extends Specification {
             
             type Foo {
                 id: ID!
-                barId: String <= $source.bazId
+                barId: String => renamed as bazId
                 qux: String!
-                anotherFoo: AnotherFoo <= $innerQueries.AnotherService.topLevel(id: $source.anotherSourceId)
+                anotherFoo: AnotherFoo => hydrated as AnotherService.topLevel(id: $source.anotherSourceId)
             }
             
-            type Bar <= $innerTypes.Baz {
+            type Bar => renamed as Baz {
                 id: ID!
             }
         }

--- a/src/test/groovy/graphql/nadel/testutils/harnesses/IssuesCommentsUsersHarness.groovy
+++ b/src/test/groovy/graphql/nadel/testutils/harnesses/IssuesCommentsUsersHarness.groovy
@@ -36,8 +36,8 @@ class IssuesCommentsUsersHarness {
                 key : String
                 summary : String
                 description : String
-                reporter : User <= $innerQueries.UserService.userById(id: $source.reporterId)
-                comments : [Comment] <= $innerQueries.CommentService.commentById(id: $source.commentIds)
+                reporter : User => hydrated as UserService.userById(id: $source.reporterId)
+                comments : [Comment] => hydrated as CommentService.commentById(id: $source.commentIds)
             }
          }
          
@@ -49,9 +49,9 @@ class IssuesCommentsUsersHarness {
             
             type Comment {
                 id : ID
-                commentText : String <= $source.text
+                commentText : String => renamed as text
                 created : String
-                author : User <= $innerQueries.UserService.userById(id: $source.authorId)
+                author : User => hydrated as UserService.userById(id: $source.authorId)
             }
         }
         

--- a/src/test/resources/type-transformation.json
+++ b/src/test/resources/type-transformation.json
@@ -24,7 +24,7 @@
               }
             }
           ],
-          "typeTransformation": {
+          "typeMappingDefinition": {
             "underlyingName": "OriginalFooName",
             "overallName": "Foo"
           }


### PR DESCRIPTION
This has new wordy syntax like the `identified by`

One point that MIGHT be contentious is the flipping of `<=` to `=>`

I strongly believe that

```
type Foo => renamed as FooName
```

reads better than

```
type Foo <= renamed as FooName
```


