### PR TITLE
relax syntax for deep arguments because they are supported already

### DIFF
--- a/src/main/antlr/StitchingDSL.g4
+++ b/src/main/antlr/StitchingDSL.g4
@@ -55,7 +55,7 @@ remoteCallDefinition : '(' remoteArgumentPair+ ')' ;
 remoteArgumentPair : name ':' remoteArgumentSource ;
 
 
-sourceObjectReference : '$source' '.' name ('.'name)?;
+sourceObjectReference : '$source' '.' name ('.'name)*;
 
 fieldArgumentReference : '$argument' '.' name ;
 


### PR DESCRIPTION
(in some cases)