### PR TITLE
Adds the service name to the underlying schema generation and a parser util

### DIFF
--- a/src/main/java/graphql/nadel/Nadel.java
+++ b/src/main/java/graphql/nadel/Nadel.java
@@ -112,7 +112,8 @@ public class Nadel {
             ServiceExecution serviceExecution = this.serviceExecutionFactory.getServiceExecution(serviceName);
             TypeDefinitionRegistry underlyingTypeDefinitions = this.serviceExecutionFactory.getUnderlyingTypeDefinitions(serviceName);
 
-            GraphQLSchema underlyingSchema = underlyingSchemaGenerator.buildUnderlyingSchema(underlyingTypeDefinitions, underlyingWiringFactory);
+            GraphQLSchema underlyingSchema = underlyingSchemaGenerator
+                    .buildUnderlyingSchema(serviceName, underlyingTypeDefinitions, underlyingWiringFactory);
             DefinitionRegistry definitionRegistry = buildServiceRegistry(serviceDefinition);
 
             Service service = new Service(serviceName, underlyingSchema, serviceExecution, serviceDefinition, definitionRegistry);

--- a/src/main/java/graphql/nadel/schema/ServiceSchemaProblem.java
+++ b/src/main/java/graphql/nadel/schema/ServiceSchemaProblem.java
@@ -1,0 +1,41 @@
+package graphql.nadel.schema;
+
+import graphql.GraphQLError;
+import graphql.GraphQLException;
+import graphql.PublicApi;
+import graphql.schema.idl.errors.SchemaProblem;
+
+import java.util.List;
+
+/**
+ * This exception wraps a {@link graphql.schema.idl.errors.SchemaProblem} and associates the specific
+ * problems with a service name
+ */
+@PublicApi
+public class ServiceSchemaProblem extends GraphQLException {
+
+    private final String serviceName;
+    private final SchemaProblem cause;
+
+    public ServiceSchemaProblem(String message, String serviceName, SchemaProblem cause) {
+        super(message, cause);
+        this.serviceName = serviceName;
+        this.cause = cause;
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public List<GraphQLError> getErrors() {
+        return cause.getErrors();
+    }
+
+    @Override
+    public String toString() {
+        return "ServiceSchemaProblem{" +
+                "service=" + serviceName +
+                ", errors=" + getErrors() +
+                '}';
+    }
+}

--- a/src/main/java/graphql/nadel/schema/UnderlyingSchemaGenerator.java
+++ b/src/main/java/graphql/nadel/schema/UnderlyingSchemaGenerator.java
@@ -5,14 +5,23 @@ import graphql.schema.idl.RuntimeWiring;
 import graphql.schema.idl.SchemaGenerator;
 import graphql.schema.idl.TypeDefinitionRegistry;
 import graphql.schema.idl.WiringFactory;
+import graphql.schema.idl.errors.SchemaProblem;
+
+import static java.lang.String.format;
 
 public class UnderlyingSchemaGenerator {
 
-    public GraphQLSchema buildUnderlyingSchema(TypeDefinitionRegistry underlyingTypeDefinitions, WiringFactory wiringFactory) {
+    public GraphQLSchema buildUnderlyingSchema(String serviceName, TypeDefinitionRegistry underlyingTypeDefinitions, WiringFactory wiringFactory) throws ServiceSchemaProblem {
         SchemaGenerator schemaGenerator = new SchemaGenerator();
         RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring()
                 .wiringFactory(new UnderlyingWiringFactory(wiringFactory))
                 .build();
-        return schemaGenerator.makeExecutableSchema(underlyingTypeDefinitions, runtimeWiring);
+        try {
+            return schemaGenerator.makeExecutableSchema(underlyingTypeDefinitions, runtimeWiring);
+        } catch (SchemaProblem schemaProblem) {
+            String message = format("There was a problem building the schema for '%s' : %s",
+                    serviceName, schemaProblem.getMessage());
+            throw new ServiceSchemaProblem(message, serviceName, schemaProblem);
+        }
     }
 }

--- a/src/main/java/graphql/nadel/util/ParseUtil.java
+++ b/src/main/java/graphql/nadel/util/ParseUtil.java
@@ -1,0 +1,37 @@
+package graphql.nadel.util;
+
+import graphql.PublicApi;
+import graphql.nadel.schema.ServiceSchemaProblem;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import graphql.schema.idl.errors.SchemaProblem;
+
+import java.io.Reader;
+
+import static java.lang.String.format;
+
+@PublicApi
+public class ParseUtil {
+
+    /**
+     * This can parse SDL text and produce a {@link graphql.schema.idl.TypeDefinitionRegistry} from that text
+     *
+     * @param serviceName the name of the service to do this on behalf of
+     * @param sdl         the SDL text
+     *
+     * @return a TypeDefinitionRegistry
+     *
+     * @throws graphql.nadel.schema.ServiceSchemaProblem in the name of the specified service
+     * @see graphql.parser.MultiSourceReader
+     */
+    public static TypeDefinitionRegistry parseServiceSDL(String serviceName, Reader sdl) throws ServiceSchemaProblem {
+        try {
+            return new SchemaParser().parse(sdl);
+        } catch (SchemaProblem schemaProblem) {
+            String message = format("There was a problem parsing the schema SDL for '%s' : %s",
+                    serviceName, schemaProblem.getMessage());
+            throw new ServiceSchemaProblem(message, serviceName, schemaProblem);
+        }
+    }
+
+}

--- a/src/test/groovy/graphql/nadel/schema/UnderlyingSchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/nadel/schema/UnderlyingSchemaGeneratorTest.groovy
@@ -1,0 +1,28 @@
+package graphql.nadel.schema
+
+import graphql.nadel.testutils.MockedWiringFactory
+import graphql.schema.idl.SchemaParser
+import spock.lang.Specification
+
+class UnderlyingSchemaGeneratorTest extends Specification {
+
+    def "exceptions are thrown in he name of the service"() {
+
+        def sdl = '''
+            type QueryMissing {
+                field : String
+            }
+        '''
+
+        def registry = new SchemaParser().parse(sdl)
+
+        when:
+        new UnderlyingSchemaGenerator().buildUnderlyingSchema("serviceX", registry, new MockedWiringFactory())
+        then:
+        def serviceSchemaProblem = thrown(ServiceSchemaProblem)
+
+        serviceSchemaProblem.getServiceName() == 'serviceX'
+        serviceSchemaProblem.getMessage().contains("There was a problem building the schema for 'serviceX'")
+        serviceSchemaProblem.getMessage().contains("There is no top level schema object defined")
+    }
+}

--- a/src/test/groovy/graphql/nadel/util/ParseUtilTest.groovy
+++ b/src/test/groovy/graphql/nadel/util/ParseUtilTest.groovy
@@ -1,0 +1,29 @@
+package graphql.nadel.util
+
+import graphql.nadel.schema.ServiceSchemaProblem
+import graphql.parser.MultiSourceReader
+import spock.lang.Specification
+
+class ParseUtilTest extends Specification {
+
+    def "parse exceptions are thrown in the name of the service"() {
+
+        def sdl = '''
+            type QueryMissing {
+                field : String
+            }
+            
+            type Bad {
+        '''
+
+
+        when:
+        def multiSourceReader = MultiSourceReader.newMultiSourceReader().string(sdl, "serviceXSDL").build()
+        ParseUtil.parseServiceSDL("serviceX", multiSourceReader)
+        then:
+        def serviceSchemaProblem = thrown(ServiceSchemaProblem)
+
+        serviceSchemaProblem.getServiceName() == 'serviceX'
+        serviceSchemaProblem.getMessage().contains("There was a problem parsing the schema SDL for 'serviceX'")
+    }
+}


### PR DESCRIPTION
This means we get better exceptions out of the Nadel instance building code