### PR TITLE
Provide Nadel hook for applying a schema transformation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 def slf4jVersion = '1.7.25'
-def graphqlJavaVersion = '2019-11-06T22-52-38-81c2a0f'
+def graphqlJavaVersion = '2020-01-08T08-53-38-a2dcfd6'
 
 def releaseVersion = System.env.RELEASE_VERSION
 version = releaseVersion ? releaseVersion : getDevelopmentVersion()

--- a/src/main/java/graphql/nadel/Nadel.java
+++ b/src/main/java/graphql/nadel/Nadel.java
@@ -366,8 +366,8 @@ public class Nadel {
             return this;
         }
 
-        public Builder schemaTransformation(SchemaTransformationHook transformation) {
-            this.schemaTransformationHook = transformation;
+        public Builder schemaTransformationHook(SchemaTransformationHook hook) {
+            this.schemaTransformationHook = hook;
             return this;
         }
 

--- a/src/main/java/graphql/nadel/Nadel.java
+++ b/src/main/java/graphql/nadel/Nadel.java
@@ -28,7 +28,7 @@ import graphql.nadel.introspection.DefaultIntrospectionRunner;
 import graphql.nadel.introspection.IntrospectionRunner;
 import graphql.nadel.schema.NeverWiringFactory;
 import graphql.nadel.schema.OverallSchemaGenerator;
-import graphql.nadel.schema.SchemaTransformation;
+import graphql.nadel.schema.SchemaTransformationHook;
 import graphql.nadel.schema.UnderlyingSchemaGenerator;
 import graphql.nadel.util.LogKit;
 import graphql.parser.InvalidSyntaxException;
@@ -75,7 +75,7 @@ public class Nadel {
     private final DefinitionRegistry commonTypes;
     private final WiringFactory overallWiringFactory;
     private final WiringFactory underlyingWiringFactory;
-    private final SchemaTransformation schemaTransformation;
+    private final SchemaTransformationHook schemaTransformationHook;
     private final OverallSchemaGenerator overallSchemaGenerator = new OverallSchemaGenerator();
 
     private Nadel(Reader nsdl,
@@ -87,13 +87,13 @@ public class Nadel {
                   ServiceExecutionHooks serviceExecutionHooks,
                   WiringFactory overallWiringFactory,
                   WiringFactory underlyingWiringFactory,
-                  SchemaTransformation schemaTransformation) {
+                  SchemaTransformationHook schemaTransformationHook) {
         this.serviceExecutionFactory = serviceExecutionFactory;
         this.instrumentation = instrumentation;
         this.serviceExecutionHooks = serviceExecutionHooks;
         this.preparsedDocumentProvider = preparsedDocumentProvider;
         this.executionIdProvider = executionIdProvider;
-        this.schemaTransformation = schemaTransformation;
+        this.schemaTransformationHook = schemaTransformationHook;
 
         this.stitchingDsl = this.NSDLParser.parseDSL(nsdl);
         this.introspectionRunner = introspectionRunner;
@@ -139,7 +139,7 @@ public class Nadel {
         GraphQLSchema schema = overallSchemaGenerator.buildOverallSchema(registries, commonTypes, overallWiringFactory);
 
         // apply transformations
-        GraphQLSchema newSchema = schemaTransformation.apply(schema);
+        GraphQLSchema newSchema = schemaTransformationHook.apply(schema);
 
         //
         // make sure that the overall schema has the standard scalars in it since he underlying may use them EVEN if the overall does not
@@ -314,7 +314,7 @@ public class Nadel {
         private IntrospectionRunner introspectionRunner = new DefaultIntrospectionRunner();
         private WiringFactory overallWiringFactory = new NeverWiringFactory();
         private WiringFactory underlyingWiringFactory = new NeverWiringFactory();
-        private SchemaTransformation schemaTransformation = new SchemaTransformation() {};
+        private SchemaTransformationHook schemaTransformationHook = new SchemaTransformationHook() {};
 
 
         public Builder dsl(Reader nsdl) {
@@ -366,8 +366,8 @@ public class Nadel {
             return this;
         }
 
-        public Builder schemaTransformation(SchemaTransformation transformation) {
-            this.schemaTransformation = transformation;
+        public Builder schemaTransformation(SchemaTransformationHook transformation) {
+            this.schemaTransformationHook = transformation;
             return this;
         }
 
@@ -382,7 +382,7 @@ public class Nadel {
                     serviceExecutionHooks,
                     overallWiringFactory,
                     underlyingWiringFactory,
-                    schemaTransformation);
+                    schemaTransformationHook);
         }
     }
 }

--- a/src/main/java/graphql/nadel/Nadel.java
+++ b/src/main/java/graphql/nadel/Nadel.java
@@ -138,7 +138,6 @@ public class Nadel {
                 .collect(toList());
         GraphQLSchema schema = overallSchemaGenerator.buildOverallSchema(registries, commonTypes, overallWiringFactory);
 
-        // apply transformations
         GraphQLSchema newSchema = schemaTransformationHook.apply(schema);
 
         //

--- a/src/main/java/graphql/nadel/Nadel.java
+++ b/src/main/java/graphql/nadel/Nadel.java
@@ -314,7 +314,7 @@ public class Nadel {
         private IntrospectionRunner introspectionRunner = new DefaultIntrospectionRunner();
         private WiringFactory overallWiringFactory = new NeverWiringFactory();
         private WiringFactory underlyingWiringFactory = new NeverWiringFactory();
-        private SchemaTransformationHook schemaTransformationHook = new SchemaTransformationHook() {};
+        private SchemaTransformationHook schemaTransformationHook = SchemaTransformationHook.IDENTITY;
 
 
         public Builder dsl(Reader nsdl) {

--- a/src/main/java/graphql/nadel/Nadel.java
+++ b/src/main/java/graphql/nadel/Nadel.java
@@ -28,6 +28,7 @@ import graphql.nadel.introspection.DefaultIntrospectionRunner;
 import graphql.nadel.introspection.IntrospectionRunner;
 import graphql.nadel.schema.NeverWiringFactory;
 import graphql.nadel.schema.OverallSchemaGenerator;
+import graphql.nadel.schema.SchemaTransformation;
 import graphql.nadel.schema.UnderlyingSchemaGenerator;
 import graphql.nadel.util.LogKit;
 import graphql.parser.InvalidSyntaxException;
@@ -74,6 +75,7 @@ public class Nadel {
     private final DefinitionRegistry commonTypes;
     private final WiringFactory overallWiringFactory;
     private final WiringFactory underlyingWiringFactory;
+    private final SchemaTransformation schemaTransformation;
     private final OverallSchemaGenerator overallSchemaGenerator = new OverallSchemaGenerator();
 
     private Nadel(Reader nsdl,
@@ -84,12 +86,14 @@ public class Nadel {
                   IntrospectionRunner introspectionRunner,
                   ServiceExecutionHooks serviceExecutionHooks,
                   WiringFactory overallWiringFactory,
-                  WiringFactory underlyingWiringFactory) {
+                  WiringFactory underlyingWiringFactory,
+                  SchemaTransformation schemaTransformation) {
         this.serviceExecutionFactory = serviceExecutionFactory;
         this.instrumentation = instrumentation;
         this.serviceExecutionHooks = serviceExecutionHooks;
         this.preparsedDocumentProvider = preparsedDocumentProvider;
         this.executionIdProvider = executionIdProvider;
+        this.schemaTransformation = schemaTransformation;
 
         this.stitchingDsl = this.NSDLParser.parseDSL(nsdl);
         this.introspectionRunner = introspectionRunner;
@@ -133,10 +137,14 @@ public class Nadel {
                 .map(Service::getDefinitionRegistry)
                 .collect(toList());
         GraphQLSchema schema = overallSchemaGenerator.buildOverallSchema(registries, commonTypes, overallWiringFactory);
+
+        // apply transformations
+        GraphQLSchema newSchema = schemaTransformation.apply(schema);
+
         //
         // make sure that the overall schema has the standard scalars in it since he underlying may use them EVEN if the overall does not
         // make direct use of them, we still have to map between them
-        return schema.transform(builder -> ScalarInfo.STANDARD_SCALARS.forEach(builder::additionalType));
+        return newSchema.transform(builder -> ScalarInfo.STANDARD_SCALARS.forEach(builder::additionalType));
     }
 
     public List<Service> getServices() {
@@ -306,6 +314,7 @@ public class Nadel {
         private IntrospectionRunner introspectionRunner = new DefaultIntrospectionRunner();
         private WiringFactory overallWiringFactory = new NeverWiringFactory();
         private WiringFactory underlyingWiringFactory = new NeverWiringFactory();
+        private SchemaTransformation schemaTransformation = new SchemaTransformation() {};
 
 
         public Builder dsl(Reader nsdl) {
@@ -357,6 +366,11 @@ public class Nadel {
             return this;
         }
 
+        public Builder schemaTransformation(SchemaTransformation transformation) {
+            this.schemaTransformation = transformation;
+            return this;
+        }
+
         public Nadel build() {
             return new Nadel(
                     nsdl,
@@ -367,7 +381,8 @@ public class Nadel {
                     introspectionRunner,
                     serviceExecutionHooks,
                     overallWiringFactory,
-                    underlyingWiringFactory);
+                    underlyingWiringFactory,
+                    schemaTransformation);
         }
     }
 }

--- a/src/main/java/graphql/nadel/schema/SchemaTransformation.java
+++ b/src/main/java/graphql/nadel/schema/SchemaTransformation.java
@@ -10,10 +10,10 @@ import graphql.schema.GraphQLSchema;
  * <p>Example usage, to delete a field:
  * <code>
  *     SchemaTransformation transformation = new SchemaTransformation() {
- *         @Override
+ *         {@literal @}Override
  *         GraphQLSchema apply(GraphQLSchema originalSchema) {
  *             return SchemaTransformer.transformSchema(originalSchema, new GraphQLTypeVisitorStub() {
- *                  @Override
+ *                  {@literal @}Override
  *                  TraversalControl visitGraphQLFieldDefinition(GraphQLFieldDefinition node, TraverserContext<GraphQLSchemaElement> context) {
  *                      if (node.getName() == "secretField") {
  *                          return TreeTransformerUtil.deleteNode(node);

--- a/src/main/java/graphql/nadel/schema/SchemaTransformation.java
+++ b/src/main/java/graphql/nadel/schema/SchemaTransformation.java
@@ -14,7 +14,7 @@ import graphql.schema.GraphQLSchema;
  *         GraphQLSchema apply(GraphQLSchema originalSchema) {
  *             return SchemaTransformer.transformSchema(originalSchema, new GraphQLTypeVisitorStub() {
  *                  {@literal @}Override
- *                  TraversalControl visitGraphQLFieldDefinition(GraphQLFieldDefinition node, TraverserContext<GraphQLSchemaElement> context) {
+ *                  TraversalControl visitGraphQLFieldDefinition(GraphQLFieldDefinition node, TraverserContext{@literal <}GraphQLSchemaElement{@literal >} context) {
  *                      if (node.getName() == "secretField") {
  *                          return TreeTransformerUtil.deleteNode(node);
  *                      }

--- a/src/main/java/graphql/nadel/schema/SchemaTransformation.java
+++ b/src/main/java/graphql/nadel/schema/SchemaTransformation.java
@@ -1,0 +1,45 @@
+package graphql.nadel.schema;
+
+import graphql.PublicSpi;
+import graphql.schema.GraphQLSchema;
+
+/**
+ * High level representation of a a graphql schema transformation. Warning: the schema resulting from the transformation
+ * is not validated by Nadel, so may produce unpredictable results if incorrect.
+ *
+ * <p>Example usage, to delete a field:
+ * <code>
+ *     SchemaTransformation transformation = new SchemaTransformation() {
+ *         @Override
+ *         GraphQLSchema apply(GraphQLSchema originalSchema) {
+ *             return SchemaTransformer.transformSchema(originalSchema, new GraphQLTypeVisitorStub() {
+ *                  @Override
+ *                  TraversalControl visitGraphQLFieldDefinition(GraphQLFieldDefinition node, TraverserContext<GraphQLSchemaElement> context) {
+ *                      if (node.getName() == "secretField") {
+ *                          return TreeTransformerUtil.deleteNode(node);
+ *                      }
+ *
+ *                      return TraversalControl.CONTINUE;
+ *                  }
+ *             }
+ *         }
+ *     }
+ * </code>
+ *
+ * @see graphql.schema.SchemaTransformer
+ * @see graphql.schema.GraphQLTypeVisitorStub
+ */
+@PublicSpi
+public interface SchemaTransformation {
+
+    /**
+     * Apply a transformation to a schema object, returning the new schema.
+     *
+     * @param originalSchema input schema
+     * @return transformed schema
+     */
+    default GraphQLSchema apply(GraphQLSchema originalSchema) {
+        return originalSchema; // no-op
+    }
+
+}

--- a/src/main/java/graphql/nadel/schema/SchemaTransformationHook.java
+++ b/src/main/java/graphql/nadel/schema/SchemaTransformationHook.java
@@ -4,8 +4,8 @@ import graphql.PublicSpi;
 import graphql.schema.GraphQLSchema;
 
 /**
- * High level representation of a a graphql schema transformation. Warning: the schema resulting from the transformation
- * is not validated by Nadel, so may produce unpredictable results if incorrect.
+ * High level representation of a transformation for an overall (not underlying) schema. Warning: the schema resulting
+ * from the transformation is not validated by Nadel, so may produce unpredictable results if incorrect.
  *
  * <p>Example usage, to delete a field:
  * <code>

--- a/src/main/java/graphql/nadel/schema/SchemaTransformationHook.java
+++ b/src/main/java/graphql/nadel/schema/SchemaTransformationHook.java
@@ -9,7 +9,7 @@ import graphql.schema.GraphQLSchema;
  *
  * <p>Example usage, to delete a field:
  * <code>
- *     SchemaTransformation transformation = new SchemaTransformation() {
+ *     SchemaTransformation transformation = originalSchema -> {
  *         {@literal @}Override
  *         GraphQLSchema apply(GraphQLSchema originalSchema) {
  *             return SchemaTransformer.transformSchema(originalSchema, new GraphQLTypeVisitorStub() {
@@ -30,7 +30,10 @@ import graphql.schema.GraphQLSchema;
  * @see graphql.schema.GraphQLTypeVisitorStub
  */
 @PublicSpi
+@FunctionalInterface
 public interface SchemaTransformationHook {
+
+    SchemaTransformationHook IDENTITY = originalSchema -> originalSchema; // no-op
 
     /**
      * Apply a transformation to a schema object, returning the new schema.
@@ -38,8 +41,6 @@ public interface SchemaTransformationHook {
      * @param originalSchema input schema
      * @return transformed schema
      */
-    default GraphQLSchema apply(GraphQLSchema originalSchema) {
-        return originalSchema; // no-op
-    }
+    GraphQLSchema apply(GraphQLSchema originalSchema);
 
 }

--- a/src/main/java/graphql/nadel/schema/SchemaTransformationHook.java
+++ b/src/main/java/graphql/nadel/schema/SchemaTransformationHook.java
@@ -9,7 +9,7 @@ import graphql.schema.GraphQLSchema;
  *
  * <p>Example usage, to delete a field:
  * <code>
- *     SchemaTransformation transformation = originalSchema -> {
+ *     SchemaTransformation transformation = originalSchema -{@literal >} {
  *         {@literal @}Override
  *         GraphQLSchema apply(GraphQLSchema originalSchema) {
  *             return SchemaTransformer.transformSchema(originalSchema, new GraphQLTypeVisitorStub() {

--- a/src/main/java/graphql/nadel/schema/SchemaTransformationHook.java
+++ b/src/main/java/graphql/nadel/schema/SchemaTransformationHook.java
@@ -30,7 +30,7 @@ import graphql.schema.GraphQLSchema;
  * @see graphql.schema.GraphQLTypeVisitorStub
  */
 @PublicSpi
-public interface SchemaTransformation {
+public interface SchemaTransformationHook {
 
     /**
      * Apply a transformation to a schema object, returning the new schema.

--- a/src/test/groovy/graphql/nadel/NadelE2ETest.groovy
+++ b/src/test/groovy/graphql/nadel/NadelE2ETest.groovy
@@ -524,7 +524,7 @@ class NadelE2ETest extends Specification {
         Nadel nadel = newNadel()
                 .dsl(simpleNDSL)
                 .serviceExecutionFactory(TestUtil.serviceFactory(delegatedExecution, underlyingSchemaChanged))
-                .schemaTransformation(transformer)
+                .schemaTransformationHook(transformer)
                 .build()
 
         NadelExecutionInput nadelExecutionInput = newNadelExecutionInput()

--- a/src/test/groovy/graphql/nadel/NadelE2ETest.groovy
+++ b/src/test/groovy/graphql/nadel/NadelE2ETest.groovy
@@ -4,7 +4,7 @@ import graphql.ErrorType
 import graphql.GraphQLError
 import graphql.execution.ExecutionId
 import graphql.execution.ExecutionIdProvider
-import graphql.nadel.schema.SchemaTransformation
+import graphql.nadel.schema.SchemaTransformationHook
 import graphql.nadel.testutils.TestUtil
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLObjectType
@@ -488,7 +488,7 @@ class NadelE2ETest extends Specification {
 
     def "schema transformation is applied"() {
         given:
-        def transformer = new SchemaTransformation() {
+        def transformer = new SchemaTransformationHook() {
             @Override
             GraphQLSchema apply(GraphQLSchema originalSchema) {
                 return SchemaTransformer.transformSchema(originalSchema, new GraphQLTypeVisitorStub() {


### PR DESCRIPTION
Extends the Nadel builder to accept a new `SchemaTransformation`
interface that accepts a graphql schema object, and returns a new schema
object.