### PR TITLE
add default batch size option

### DIFF
--- a/src/main/antlr/StitchingDSL.g4
+++ b/src/main/antlr/StitchingDSL.g4
@@ -26,8 +26,9 @@ enumTypeDefinition : description? ENUM name directives? typeTransformation? enum
 scalarTypeDefinition : description? SCALAR name directives? typeTransformation?;
 
 
-fieldDefinition : description? name argumentsDefinition? ':' type directives? fieldTransformation?;
-
+fieldDefinition : description? name argumentsDefinition? ':' type directives? addFieldInfo? fieldTransformation?;
+addFieldInfo: defaultBatchSize;
+defaultBatchSize:'default batch size' intValue;
 fieldTransformation : '=>' (fieldMappingDefinition | underlyingServiceHydration);
 
 typeTransformation : '=>' typeMappingDefinition;

--- a/src/main/java/graphql/nadel/NadelAntlrToLanguage.java
+++ b/src/main/java/graphql/nadel/NadelAntlrToLanguage.java
@@ -11,7 +11,7 @@ import graphql.language.ScalarTypeDefinition;
 import graphql.language.UnionTypeDefinition;
 import graphql.nadel.dsl.CommonDefinition;
 import graphql.nadel.dsl.EnumTypeDefinitionWithTransformation;
-import graphql.nadel.dsl.FieldDefinitionWithTransformation;
+import graphql.nadel.dsl.ExtendedFieldDefinition;
 import graphql.nadel.dsl.FieldMappingDefinition;
 import graphql.nadel.dsl.FieldTransformation;
 import graphql.nadel.dsl.InputObjectTypeDefinitionWithTransformation;
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static graphql.Assert.assertShouldNeverHappen;
-import static graphql.nadel.dsl.FieldDefinitionWithTransformation.newFieldDefinitionWithTransformation;
+import static graphql.nadel.dsl.ExtendedFieldDefinition.newExtendedFieldDefinition;
 import static graphql.nadel.dsl.RemoteArgumentSource.SourceType.CONTEXT;
 import static graphql.nadel.dsl.RemoteArgumentSource.SourceType.FIELD_ARGUMENT;
 import static graphql.nadel.dsl.RemoteArgumentSource.SourceType.OBJECT_FIELD;
@@ -86,11 +86,16 @@ public class NadelAntlrToLanguage extends GraphqlAntlrToLanguage {
     @Override
     protected FieldDefinition createFieldDefinition(StitchingDSLParser.FieldDefinitionContext ctx) {
         FieldDefinition fieldDefinition = super.createFieldDefinition(ctx);
-        if (ctx.fieldTransformation() == null) {
+        if (ctx.fieldTransformation() == null && ctx.addFieldInfo() == null) {
             return fieldDefinition;
         }
-        FieldDefinitionWithTransformation.Builder builder = newFieldDefinitionWithTransformation(fieldDefinition);
-        builder.fieldTransformation(createFieldTransformation(ctx.fieldTransformation()));
+        ExtendedFieldDefinition.Builder builder = newExtendedFieldDefinition(fieldDefinition);
+        if (ctx.fieldTransformation() != null) {
+            builder.fieldTransformation(createFieldTransformation(ctx.fieldTransformation()));
+        }
+        if (ctx.addFieldInfo() != null) {
+            builder.defaultBatchSize(Integer.parseInt(ctx.addFieldInfo().defaultBatchSize().intValue().getText()));
+        }
         return builder.build();
     }
 

--- a/src/main/java/graphql/nadel/dsl/ExtendedFieldDefinition.java
+++ b/src/main/java/graphql/nadel/dsl/ExtendedFieldDefinition.java
@@ -16,27 +16,34 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class FieldDefinitionWithTransformation extends FieldDefinition {
+public class ExtendedFieldDefinition extends FieldDefinition {
 
     private final FieldTransformation fieldTransformation;
 
+    private Integer defaultBatchSize;
 
-    protected FieldDefinitionWithTransformation(String name,
-                                                Type type,
-                                                List<InputValueDefinition> inputValueDefinitions,
-                                                List<Directive> directives,
-                                                Description description,
-                                                FieldTransformation fieldTransformation, SourceLocation sourceLocation,
-                                                List<Comment> comments) {
+    protected ExtendedFieldDefinition(String name,
+                                      Type type,
+                                      List<InputValueDefinition> inputValueDefinitions,
+                                      List<Directive> directives,
+                                      Description description,
+                                      FieldTransformation fieldTransformation, SourceLocation sourceLocation,
+                                      List<Comment> comments,
+                                      Integer defaultBatchSize) {
         super(name, type, inputValueDefinitions, directives, description, sourceLocation, comments, IgnoredChars.EMPTY, Collections.emptyMap());
         this.fieldTransformation = fieldTransformation;
+        this.defaultBatchSize = defaultBatchSize;
     }
 
     public FieldTransformation getFieldTransformation() {
         return fieldTransformation;
     }
 
-    public static Builder newFieldDefinitionWithTransformation(FieldDefinition copyFrom) {
+    public Integer getDefaultBatchSize() {
+        return defaultBatchSize;
+    }
+
+    public static Builder newExtendedFieldDefinition(FieldDefinition copyFrom) {
         return new Builder(copyFrom);
     }
 
@@ -49,6 +56,7 @@ public class FieldDefinitionWithTransformation extends FieldDefinition {
         private List<InputValueDefinition> inputValueDefinitions = new ArrayList<>();
         private List<Directive> directives = new ArrayList<>();
         private FieldTransformation fieldTransformation;
+        private Integer defaultBatchSize;
 
         private Builder() {
         }
@@ -129,15 +137,21 @@ public class FieldDefinitionWithTransformation extends FieldDefinition {
             return this;
         }
 
-        public FieldDefinitionWithTransformation build() {
-            FieldDefinitionWithTransformation fieldDefinition = new FieldDefinitionWithTransformation(name,
+        public Builder defaultBatchSize(Integer defaultBatchSize) {
+            this.defaultBatchSize = defaultBatchSize;
+            return this;
+        }
+
+        public ExtendedFieldDefinition build() {
+            ExtendedFieldDefinition fieldDefinition = new ExtendedFieldDefinition(name,
                     type,
                     inputValueDefinitions,
                     directives,
                     description,
                     fieldTransformation,
                     sourceLocation,
-                    comments);
+                    comments,
+                    defaultBatchSize);
             return fieldDefinition;
         }
     }

--- a/src/main/java/graphql/nadel/engine/OverallQueryTransformer.java
+++ b/src/main/java/graphql/nadel/engine/OverallQueryTransformer.java
@@ -23,7 +23,7 @@ import graphql.language.VariableDefinition;
 import graphql.language.VariableReference;
 import graphql.nadel.Operation;
 import graphql.nadel.Service;
-import graphql.nadel.dsl.FieldDefinitionWithTransformation;
+import graphql.nadel.dsl.ExtendedFieldDefinition;
 import graphql.nadel.dsl.TypeMappingDefinition;
 import graphql.nadel.engine.transformation.ApplyEnvironment;
 import graphql.nadel.engine.transformation.ApplyResult;
@@ -737,8 +737,8 @@ public class OverallQueryTransformer {
 
 
     private graphql.nadel.dsl.FieldTransformation transformationDefinitionForField(FieldDefinition definition) {
-        if (definition instanceof FieldDefinitionWithTransformation) {
-            return ((FieldDefinitionWithTransformation) definition).getFieldTransformation();
+        if (definition instanceof ExtendedFieldDefinition) {
+            return ((ExtendedFieldDefinition) definition).getFieldTransformation();
         }
         return null;
     }

--- a/src/test/groovy/graphql/nadel/engine/NadelExecutionStrategyTest.groovy
+++ b/src/test/groovy/graphql/nadel/engine/NadelExecutionStrategyTest.groovy
@@ -2259,5 +2259,94 @@ fragment F1 on TestingCharacter {
 
     }
 
+    def "batching with default batch size"() {
+        given:
+        def issueSchema = TestUtil.schema("""
+        type Query {
+            issues : [Issue]
+        }
+        type Issue {
+            id: ID
+            authorIds: [ID]
+        }
+        """)
+        def userServiceSchema = TestUtil.schema("""
+        type Query {
+            usersByIds(id: [ID]): [User] 
+        }
+        type User {
+            id: ID
+        }
+        """)
+
+        def overallSchema = TestUtil.schemaFromNdsl('''
+        service Issues {
+            type Query {
+                issues: [Issue]
+            }
+            type Issue {
+                id: ID
+                authors: [User] => hydrated from UserService.usersByIds(id: $source.authorIds) object identified by id
+            }
+        }
+        service UserService {
+            type Query {
+                usersByIds(id: [ID]): [User] default batch size 3
+            }
+            type User {
+                id: ID
+            }
+        }
+        ''')
+        def issuesFieldDefinition = overallSchema.getQueryType().getFieldDefinition("issues")
+
+        def service1 = new Service("Issues", issueSchema, service1Execution, serviceDefinition, definitionRegistry)
+        def service2 = new Service("UserService", userServiceSchema, service2Execution, serviceDefinition, definitionRegistry)
+        def fieldInfos = topLevelFieldInfo(issuesFieldDefinition, service1)
+        NadelExecutionStrategy nadelExecutionStrategy = new NadelExecutionStrategy([service1, service2], fieldInfos, overallSchema, instrumentation, serviceExecutionHooks)
+
+
+        def query = "{issues {id authors {id}}}"
+        def expectedQuery1 = "query nadel_2_Issues {issues {id authorIds}}"
+        def issue1 = [id: "ISSUE-1", authorIds: ["USER-1", "USER-2"]]
+        def issue2 = [id: "ISSUE-2", authorIds: ["USER-3"]]
+        def issue3 = [id: "ISSUE-3", authorIds: ["USER-2", "USER-4", "USER-5",]]
+        def response1 = new ServiceExecutionResult([issues: [issue1, issue2, issue3]])
+
+
+        def expectedQuery2 = "query nadel_2_UserService {usersByIds(id:[\"USER-1\",\"USER-2\",\"USER-3\"]) {id object_identifier__UUID:id}}"
+        def batchResponse1 = [[id: "USER-1", object_identifier__UUID: "USER-1"], [id: "USER-2", object_identifier__UUID: "USER-2"], [id: "USER-3", object_identifier__UUID: "USER-3"]]
+        def response2 = new ServiceExecutionResult([usersByIds: batchResponse1])
+
+        def expectedQuery3 = "query nadel_2_UserService {usersByIds(id:[\"USER-2\",\"USER-4\",\"USER-5\"]) {id object_identifier__UUID:id}}"
+        def batchResponse2 = [[id: "USER-2", object_identifier__UUID: "USER-2"], [id: "USER-4", object_identifier__UUID: "USER-4"], [id: "USER-5", object_identifier__UUID: "USER-5"]]
+        def response3 = new ServiceExecutionResult([usersByIds: batchResponse2])
+
+        def executionData = createExecutionData(query, overallSchema)
+
+        when:
+        def response = nadelExecutionStrategy.execute(executionData.executionContext, executionData.fieldSubSelection)
+
+
+        then:
+        1 * service1Execution.execute({ ServiceExecutionParameters sep ->
+            printAstCompact(sep.query) == expectedQuery1
+        }) >> completedFuture(response1)
+
+        then:
+        1 * service2Execution.execute({ ServiceExecutionParameters sep ->
+            printAstCompact(sep.query) == expectedQuery2
+        }) >> completedFuture(response2)
+        1 * service2Execution.execute({ ServiceExecutionParameters sep ->
+            printAstCompact(sep.query) == expectedQuery3
+        }) >> completedFuture(response3)
+
+
+        def issue1Result = [id: "ISSUE-1", authors: [[id: "USER-1"], [id: "USER-2"]]]
+        def issue2Result = [id: "ISSUE-2", authors: [[id: "USER-3"]]]
+        def issue3Result = [id: "ISSUE-3", authors: [[id: "USER-2"], [id: "USER-4"], [id: "USER-5"]]]
+        resultData(response) == [issues: [issue1Result, issue2Result, issue3Result]]
+
+    }
 
 }


### PR DESCRIPTION
This adds an additional config option for a field to specify the default batch size if others use it to hydrate data:

```graphql 
service UserService {
  type Query {
    usersByIds(id: [ID]): [User] default batch size 3
   }
}
```