### PR TITLE
improve performance by refactoring the artificial fields removal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 def slf4jVersion = '1.7.25'
-def graphqlJavaVersion = '14.0'
+def graphqlJavaVersion = '2020-02-03T01-49-24-d4f9b63'
 
 def releaseVersion = System.env.RELEASE_VERSION
 version = releaseVersion ? releaseVersion : getDevelopmentVersion()

--- a/src/main/java/graphql/nadel/Nadel.java
+++ b/src/main/java/graphql/nadel/Nadel.java
@@ -143,7 +143,7 @@ public class Nadel {
         //
         // make sure that the overall schema has the standard scalars in it since he underlying may use them EVEN if the overall does not
         // make direct use of them, we still have to map between them
-        return newSchema.transform(builder -> ScalarInfo.STANDARD_SCALARS.forEach(builder::additionalType));
+        return newSchema.transform(builder -> ScalarInfo.GRAPHQL_SPECIFICATION_SCALARS.forEach(builder::additionalType));
     }
 
     public List<Service> getServices() {

--- a/src/main/java/graphql/nadel/engine/HydrationInputResolver.java
+++ b/src/main/java/graphql/nadel/engine/HydrationInputResolver.java
@@ -46,7 +46,6 @@ import static graphql.Assert.assertNotNull;
 import static graphql.Assert.assertTrue;
 import static graphql.language.Field.newField;
 import static graphql.nadel.engine.ArtificialFieldUtils.addObjectIdentifier;
-import static graphql.nadel.engine.ArtificialFieldUtils.removeArtificialFields;
 import static graphql.nadel.engine.FixListNamesAdapter.FIX_NAMES_ADAPTER;
 import static graphql.nadel.engine.StrategyUtil.changeEsiInResultNode;
 import static graphql.nadel.engine.StrategyUtil.changeFieldInResultNode;
@@ -246,8 +245,7 @@ public class HydrationInputResolver {
 
         ForkJoinPool forkJoinPool = getNadelContext(executionContext).getForkJoinPool();
         return serviceResult
-                .thenApply(resultNode -> removeArtificialFieldsFromRoot(executionContext, resultNode))
-                .thenApply(resultNode -> convertSingleHydrationResultIntoOverallResult(executionContext.getExecutionId(), forkJoinPool, fieldTracking, hydratedFieldStepInfo, hydrationTransformation, resultNode, queryTransformationResult))
+                .thenApply(resultNode -> convertSingleHydrationResultIntoOverallResult(executionContext.getExecutionId(), forkJoinPool, fieldTracking, hydratedFieldStepInfo, hydrationTransformation, resultNode, queryTransformationResult, getNadelContext(executionContext)))
                 .whenComplete(fieldTracking::fieldsCompleted)
                 .whenComplete(this::possiblyLogException);
 
@@ -274,14 +272,15 @@ public class HydrationInputResolver {
                                                                               ExecutionStepInfo hydratedFieldStepInfo,
                                                                               HydrationTransformation hydrationTransformation,
                                                                               RootExecutionResultNode rootResultNode,
-                                                                              QueryTransformationResult queryTransformationResult) {
+                                                                              QueryTransformationResult queryTransformationResult,
+                                                                              NadelContext nadelContext) {
 
         synthesizeHydratedParentIfNeeded(fieldTracking, hydratedFieldStepInfo);
 
         Map<String, FieldTransformation> transformationByResultField = queryTransformationResult.getTransformationByResultField();
         Map<String, String> typeRenameMappings = queryTransformationResult.getTypeRenameMappings();
         ExecutionResultNode firstTopLevelResultNode = serviceResultNodesToOverallResult
-                .convertChildren(executionId, forkJoinPool, rootResultNode.getChildren().get(0), overallSchema, hydratedFieldStepInfo, true, false, transformationByResultField, typeRenameMappings);
+                .convertChildren(executionId, forkJoinPool, rootResultNode.getChildren().get(0), overallSchema, hydratedFieldStepInfo, true, false, transformationByResultField, typeRenameMappings, nadelContext);
         firstTopLevelResultNode = firstTopLevelResultNode.withNewErrors(rootResultNode.getErrors());
         firstTopLevelResultNode = changeEsiInResultNode(firstTopLevelResultNode, hydratedFieldStepInfo);
 
@@ -316,7 +315,6 @@ public class HydrationInputResolver {
         return serviceExecutor
                 .execute(executionContext, queryTransformationResult, service, operation, serviceContexts.get(service), true)
                 .thenApply(resultNode -> convertHydrationBatchResultIntoOverallResult(executionContext, fieldTracking, hydrationInputs, resultNode, queryTransformationResult))
-                .thenApply(resultNode -> ArtificialFieldUtils.removeArtificialFields(getNadelContext(executionContext), resultNode))
                 .whenComplete(fieldTracking::fieldsCompleted)
                 .whenComplete(this::possiblyLogException);
 
@@ -399,7 +397,8 @@ public class HydrationInputResolver {
                         true,
                         true,
                         transformationByResultField,
-                        typeRenameMappings);
+                        typeRenameMappings,
+                        getNadelContext(executionContext));
                 Field originalField = hydrationInputNode.getHydrationTransformation().getOriginalField();
                 resultNode = changeFieldInResultNode(overallResultNode, originalField);
             } else {
@@ -439,9 +438,6 @@ public class HydrationInputResolver {
         return null;
     }
 
-    private RootExecutionResultNode removeArtificialFieldsFromRoot(ExecutionContext executionContext, RootExecutionResultNode root) {
-        return (RootExecutionResultNode) removeArtificialFields(getNadelContext(executionContext), root);
-    }
 
     private LeafExecutionResultNode getFieldByResultKey(ObjectExecutionResultNode node, String resultKey) {
         return (LeafExecutionResultNode) findOneOrNull(node.getChildren(), child -> child.getMergedField().getResultKey().equals(resultKey));

--- a/src/main/java/graphql/nadel/schema/NeverWiringFactory.java
+++ b/src/main/java/graphql/nadel/schema/NeverWiringFactory.java
@@ -24,7 +24,7 @@ public class NeverWiringFactory implements WiringFactory {
     @Override
     public boolean providesScalar(ScalarWiringEnvironment environment) {
         final String scalarName = environment.getScalarTypeDefinition().getName();
-        return !(ScalarInfo.isStandardScalar(scalarName) || ScalarInfo.isGraphqlSpecifiedScalar(scalarName));
+        return !(ScalarInfo.isGraphqlSpecifiedScalar(scalarName));
     }
 
     @Override

--- a/src/test/groovy/graphql/nadel/engine/transformation/variables/InputValueFinderTest.groovy
+++ b/src/test/groovy/graphql/nadel/engine/transformation/variables/InputValueFinderTest.groovy
@@ -10,7 +10,7 @@ class InputValueFinderTest extends Specification {
 
     def sdl = '''
         
-        directive @directive1 on ARGUMENT_DEFINITION | FIELD_DEFINITION
+        directive @directive1 on ARGUMENT_DEFINITION | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
         directive @argDirective on ARGUMENT_DEFINITION
 
         enum RGB {

--- a/src/test/groovy/graphql/nadel/engine/transformation/variables/InputValueTransformerTest.groovy
+++ b/src/test/groovy/graphql/nadel/engine/transformation/variables/InputValueTransformerTest.groovy
@@ -9,7 +9,7 @@ class InputValueTransformerTest extends Specification {
 
     def sdl = '''
         
-        directive @directive1 on ARGUMENT_DEFINITION | FIELD_DEFINITION
+        directive @directive1 on ARGUMENT_DEFINITION | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
         enum RGB {
             red, blue,green

--- a/src/test/groovy/graphql/nadel/testutils/TestUtil.groovy
+++ b/src/test/groovy/graphql/nadel/testutils/TestUtil.groovy
@@ -135,7 +135,7 @@ class TestUtil {
         def stream = TestUtil.class.getClassLoader().getResourceAsStream(fileName)
 
         def typeRegistry = new SchemaParser().parse(new InputStreamReader(stream))
-        def options = SchemaGenerator.Options.defaultOptions().enforceSchemaDirectives(false)
+        def options = SchemaGenerator.Options.defaultOptions()
         def schema = new SchemaGenerator().makeExecutableSchema(options, typeRegistry, wiring)
         schema
     }
@@ -183,7 +183,7 @@ class TestUtil {
     static GraphQLSchema schema(Reader specReader, RuntimeWiring runtimeWiring) {
         try {
             def registry = new SchemaParser().parse(specReader)
-            def options = SchemaGenerator.Options.defaultOptions().enforceSchemaDirectives(false)
+            def options = SchemaGenerator.Options.defaultOptions()
             return new SchemaGenerator().makeExecutableSchema(options, registry, runtimeWiring)
         } catch (SchemaProblem e) {
             assert false: "The schema could not be compiled : ${e}"


### PR DESCRIPTION
This improves the improves by moving the articial fields removal into the service result nodes to overall result steps.

The benchmark improvements are (tested with the LargeResponse jmh test):
45.036 ± 2.010  ms/op down to 41.579 ± 8.023  ms/op with 8 threads

 7.960 ± 0.556  ms/op down to 15  6.589 ± 0.354  ms/op with 1 thread

