### PR TITLE
Fix __typename value if the type has been renamed in NDSL

### DIFF
--- a/src/main/java/graphql/nadel/engine/ArtificialFieldUtils.java
+++ b/src/main/java/graphql/nadel/engine/ArtificialFieldUtils.java
@@ -1,6 +1,7 @@
 package graphql.nadel.engine;
 
 import graphql.execution.MergedField;
+import graphql.introspection.Introspection;
 import graphql.language.Field;
 import graphql.language.SelectionSet;
 import graphql.nadel.util.Util;
@@ -15,7 +16,7 @@ import static graphql.Assert.assertNotNull;
  */
 public class ArtificialFieldUtils {
 
-    private static final String UNDERSCORE_TYPENAME = "__typename";
+    private static final String UNDERSCORE_TYPENAME = Introspection.TypeNameMetaFieldDef.getName();
 
     public static Field maybeAddUnderscoreTypeName(NadelContext nadelContext, Field field, GraphQLOutputType fieldType) {
         if (!Util.isInterfaceOrUnionField(fieldType)) {

--- a/src/main/java/graphql/nadel/engine/ResolvedValueMapper.java
+++ b/src/main/java/graphql/nadel/engine/ResolvedValueMapper.java
@@ -1,0 +1,22 @@
+package graphql.nadel.engine;
+
+import graphql.execution.nextgen.result.ExecutionResultNode;
+import graphql.execution.nextgen.result.ResolvedValue;
+import graphql.introspection.Introspection;
+
+public class ResolvedValueMapper {
+
+    private static final String UNDERSCORE_TYPENAME = Introspection.TypeNameMetaFieldDef.getName();
+
+    public ResolvedValue mapResolvedValue(ExecutionResultNode node, UnapplyEnvironment environment) {
+        if (node.getMergedField().getName().equals(UNDERSCORE_TYPENAME)) {
+            String type = (String) node.getResolvedValue().getCompletedValue();
+            String renamed = environment.typeRenameMappings.get(type);
+            if (renamed != null) {
+                return node.getResolvedValue().transform(builder -> builder.completedValue(renamed).build());
+            }
+        }
+
+        return node.getResolvedValue();
+    }
+}

--- a/src/main/java/graphql/nadel/engine/ServiceResultNodesToOverallResult.java
+++ b/src/main/java/graphql/nadel/engine/ServiceResultNodesToOverallResult.java
@@ -6,6 +6,7 @@ import graphql.execution.ExecutionStepInfo;
 import graphql.execution.MergedField;
 import graphql.execution.nextgen.result.ExecutionResultNode;
 import graphql.execution.nextgen.result.LeafExecutionResultNode;
+import graphql.execution.nextgen.result.ResolvedValue;
 import graphql.execution.nextgen.result.RootExecutionResultNode;
 import graphql.language.AbstractNode;
 import graphql.language.Field;
@@ -44,6 +45,8 @@ import static java.util.Collections.singletonMap;
 public class ServiceResultNodesToOverallResult {
 
     ExecutionStepInfoMapper executionStepInfoMapper = new ExecutionStepInfoMapper();
+
+    ResolvedValueMapper resolvedValueMapper = new ResolvedValueMapper();
 
     ResultNodesTransformer resultNodesTransformer = new ResultNodesTransformer();
 
@@ -327,9 +330,9 @@ public class ServiceResultNodesToOverallResult {
     }
 
     private ExecutionResultNode mapNode(ExecutionResultNode node, UnapplyEnvironment environment, TraverserContext<ExecutionResultNode> context) {
-
         ExecutionStepInfo mappedEsi = executionStepInfoMapper.mapExecutionStepInfo(node.getExecutionStepInfo(), environment);
-        return node.withNewExecutionStepInfo(mappedEsi);
+        ResolvedValue mappedResolvedValue = resolvedValueMapper.mapResolvedValue(node, environment);
+        return node.withNewExecutionStepInfo(mappedEsi).withNewResolvedValue(mappedResolvedValue);
     }
 
     private void mapAndChangeNode(ExecutionResultNode node, UnapplyEnvironment environment, TraverserContext<ExecutionResultNode> context) {

--- a/src/main/java/graphql/nadel/engine/transformation/FieldTransformation.java
+++ b/src/main/java/graphql/nadel/engine/transformation/FieldTransformation.java
@@ -84,8 +84,8 @@ public abstract class FieldTransformation {
                             .field(newMergedField)
                             .fieldDefinition(allTransformations.get(0).getOriginalFieldDefinition())
                             .type(originalFieldType);
-            if (parentEsi != null && unwrapAll(parentEsi.getType()) instanceof GraphQLObjectType) {
-                builder.fieldContainer((GraphQLObjectType) unwrapAll(parentEsi.getType()));
+                    if (parentEsi != null && unwrapAll(parentEsi.getType()) instanceof GraphQLObjectType) {
+                        builder.fieldContainer((GraphQLObjectType) unwrapAll(parentEsi.getType()));
                     }
                 }
 

--- a/src/test/groovy/graphql/nadel/engine/ResolvedValueMapperTest.groovy
+++ b/src/test/groovy/graphql/nadel/engine/ResolvedValueMapperTest.groovy
@@ -1,0 +1,63 @@
+package graphql.nadel.engine
+
+import graphql.execution.ExecutionStepInfo
+import graphql.execution.MergedField
+import graphql.execution.nextgen.result.ExecutionResultNode
+import graphql.execution.nextgen.result.ResolvedValue
+import graphql.introspection.Introspection
+import graphql.schema.GraphQLSchema
+import spock.lang.Specification
+
+import java.util.function.Consumer
+
+class ResolvedValueMapperTest extends Specification {
+    def mapper = new ResolvedValueMapper()
+
+    def "changes __typename field value accordingly"(String given, String expected) {
+        given:
+        def mapping = ["Underlying": "Exposed", "A": "B", "C": "D"]
+        def unapplyEnvironment = new UnapplyEnvironment(Mock(ExecutionStepInfo), false, false, mapping, Mock(GraphQLSchema))
+        def node = newNode { builder -> builder.completedValue(given) }
+
+        when:
+        def mapped = mapper.mapResolvedValue(node, unapplyEnvironment)
+
+        then:
+        mapped.completedValue == expected
+
+        where:
+        given        | expected
+        "Underlying" | "Exposed"
+        "A"          | "B"
+        "B"          | "B"
+        "C"          | "D"
+        "D"          | "D"
+        "Unmapped"   | "Unmapped"
+    }
+
+    def "leaves non __typename fields alone"() {
+        given:
+        def mapping = ["Underlying": "Exposed", "A": "B", "C": "D"]
+        def unapplyEnvironment = new UnapplyEnvironment(Mock(ExecutionStepInfo), false, false, mapping, Mock(GraphQLSchema))
+        def node = newNode({ builder -> builder.completedValue("Underlying") }, "__someField")
+
+        when:
+        def mapped = mapper.mapResolvedValue(node, unapplyEnvironment)
+
+        then:
+        mapped.is(node.resolvedValue)
+        mapped.completedValue == "Underlying"
+    }
+
+    def newNode(Consumer<ResolvedValue.Builder> valueBuilder, String name = Introspection.TypeNameMetaFieldDef.name) {
+        def node = Mock(ExecutionResultNode)
+        def field = Mock(MergedField)
+        def value = ResolvedValue.newResolvedValue().with({ valueBuilder.accept(it); it }).build()
+
+        (1.._) * node.resolvedValue >> value
+        (1.._) * node.mergedField >> field
+        (1.._) * field.name >> name
+
+        return node
+    }
+}


### PR DESCRIPTION
Previously Nadel would not change the value of `__typename` and the underlying type name would be exposed instead of the renamed type name e.g.

NDSL:

```
service Test {
    type Query {
        test: Exposed
    }

    type Exposed => renamed from Underlying {
        id: ID
    }
}
```

GSDL:

```
type Query {
    test: Underlying
}

type Underlying {
    id: ID
}
```

The query:

```
{
    test {
        __typename
    }
}
```

Would return:

```
{
    "data": {
        "test": {
            "__typename": "Underlying"
        }
    }
}
```

Rather than:


```
{
    "data": {
        "test": {
            "__typename": "Exposed"
        }
    }
}
```