### PR TITLE
Blow up on redefinition

### DIFF
--- a/src/test/groovy/graphql/nadel/schema/OverallSchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/nadel/schema/OverallSchemaGeneratorTest.groovy
@@ -1,7 +1,6 @@
 package graphql.nadel.schema
 
 import graphql.GraphQLException
-import graphql.language.ObjectTypeDefinition
 import graphql.nadel.Operation
 import graphql.nadel.testutils.TestUtil
 import graphql.schema.GraphQLObjectType
@@ -333,6 +332,33 @@ class OverallSchemaGeneratorTest extends Specification {
         then:
         result.queryType.fieldDefinitions.collect { it.name } == ["a", "c"]
         (result.typeMap["A"] as GraphQLObjectType).fieldDefinitions.collect { it.name } == ["x"]
+    }
+
+    def "services can still extend types"() {
+        when:
+        def result = TestUtil.schemaFromNdsl("""
+        service S1 {
+            type Query {
+                a: String
+            }
+            type A {
+                x: String
+            }
+        }
+        service S2 {
+            type Query {
+                c: String
+            }
+            extend type A {
+                y: String 
+            }
+        }
+        """)
+
+
+        then:
+        result.queryType.fieldDefinitions.collect { it.name } == ["a", "c"]
+        (result.typeMap["A"] as GraphQLObjectType).fieldDefinitions.collect { it.name } == ["x", "y"]
     }
 
 }


### PR DESCRIPTION
Currently we accept types that are redefined in Nadel. This becomes an issue when the multiple type definitions differ e.g.

```
service A {
    type GenericResponse {
        message: String
    }
}
service B {
    type GenericResponse {
        message: String
        someExtraField: String
    }
}
```

Depending on the order of parsing `someExtraField` may not be in the overall schema.

This PR raises an exception if there are types that are redefined in the NDSL.