### PR TITLE
Blow up on bad syntax

### DIFF
--- a/src/main/java/graphql/nadel/NSDLParser.java
+++ b/src/main/java/graphql/nadel/NSDLParser.java
@@ -46,6 +46,8 @@ public class NSDLParser {
         }
 
         StitchingDSLLexer lexer = new StitchingDSLLexer(charStream);
+        lexer.removeErrorListeners();
+        lexer.addErrorListener(ThrowingErrorListener.INSTANCE);
         CommonTokenStream tokens = new CommonTokenStream(lexer);
         StitchingDSLParser parser = new StitchingDSLParser(tokens);
         parser.removeErrorListeners();

--- a/src/test/groovy/graphql/nadel/NSDLParserTest.groovy
+++ b/src/test/groovy/graphql/nadel/NSDLParserTest.groovy
@@ -216,6 +216,26 @@ class NSDLParserTest extends Specification {
         assertNodesHaveIds(stitchingDSL.children)
     }
 
+    def "unterminated string should not parse"() {
+        given:
+        def dsl = """
+            service FooService {
+                type Query {
+                    "this is an unterminated comment
+                    echo: String
+                }
+            }
+        """
+
+        when:
+        NSDLParser parser = new NSDLParser()
+        parser.parseDSL(dsl)
+
+        then:
+        def parseException = thrown ParseCancellationException
+        parseException.message.contains("token recognition error at: '\"this is an unterminated comment\\n'")
+    }
+
     def "parse directives to wrong place for field transformation"() {
         given:
 


### PR DESCRIPTION
Seems like an error listener needs to be applied to the lexer too. Would previously print to stderr and recover.