### PR TITLE
Better message on missing underlying schema object

### DIFF
--- a/src/main/java/graphql/nadel/engine/Transformer.java
+++ b/src/main/java/graphql/nadel/engine/Transformer.java
@@ -255,7 +255,7 @@ public class Transformer extends NodeVisitorStub {
     private void updateTypeContext(TraverserContext<Node> context, GraphQLOutputType currentOutputTypeUnderlying, String fieldContainerName) {
         Field newField = (Field) context.thisNode();
         GraphQLFieldsContainer fieldsContainerUnderlying = (GraphQLFieldsContainer) unwrapAll(currentOutputTypeUnderlying);
-        assertTrue(fieldsContainerUnderlying instanceof GraphQLFieldsContainer, () -> String.format("Schema mismatch: Underlying schema is missing required Object or Interface %s", fieldContainerName));
+        assertTrue(fieldsContainerUnderlying instanceof GraphQLFieldsContainer, () -> String.format("Schema mismatch: Underlying schema is missing required Interface Type %s", fieldContainerName));
 
         GraphQLFieldDefinition fieldDefinitionUnderlying = Introspection.getFieldDef(underlyingSchema, fieldsContainerUnderlying, newField.getName());
         GraphQLOutputType newOutputTypeUnderlying = fieldDefinitionUnderlying.getType();

--- a/src/main/java/graphql/nadel/engine/Transformer.java
+++ b/src/main/java/graphql/nadel/engine/Transformer.java
@@ -207,7 +207,7 @@ public class Transformer extends NodeVisitorStub {
 
         GraphQLFieldDefinition fieldDefinitionOverall = overallTypeInfo.getFieldDefinition();
         GraphQLNamedOutputType fieldTypeOverall = (GraphQLNamedOutputType) GraphQLTypeUtil.unwrapAll(fieldDefinitionOverall.getType());
-        String fieldContainerName = overallTypeInfo.getFieldsContainer().getName();
+
 
         NormalizedQueryFromAst normalizedOverallQuery = nadelContext.getNormalizedOverallQuery();
         List<NormalizedQueryField> normalizedFields = normalizedOverallQuery.getNormalizedFieldsByFieldId(getId(field));
@@ -237,27 +237,21 @@ public class Transformer extends NodeVisitorStub {
                 maybeAddUnderscoreTypeName(context, changedField, fieldTypeOverall);
             }
             if (applyResult.getTraversalControl() == TraversalControl.CONTINUE) {
-                updateTypeContext(context, typeContext.getOutputTypeUnderlying(), fieldContainerName);
+                updateTypeContext(context, typeContext.getOutputTypeUnderlying());
             }
             return applyResult.getTraversalControl();
 
         } else {
             maybeAddUnderscoreTypeName(context, field, fieldTypeOverall);
         }
-        updateTypeContext(context, typeContext.getOutputTypeUnderlying(), fieldContainerName);
+        updateTypeContext(context, typeContext.getOutputTypeUnderlying());
         return TraversalControl.CONTINUE;
     }
 
+
     private void updateTypeContext(TraverserContext<Node> context, GraphQLOutputType currentOutputTypeUnderlying) {
-        updateTypeContext(context, currentOutputTypeUnderlying, null);
-    }
-
-
-    private void updateTypeContext(TraverserContext<Node> context, GraphQLOutputType currentOutputTypeUnderlying, String fieldContainerName) {
         Field newField = (Field) context.thisNode();
         GraphQLFieldsContainer fieldsContainerUnderlying = (GraphQLFieldsContainer) unwrapAll(currentOutputTypeUnderlying);
-        assertTrue(fieldsContainerUnderlying instanceof GraphQLFieldsContainer, () -> String.format("Schema Mismatch: Underlying schema is missing the required field %s", fieldContainerName));
-
         GraphQLFieldDefinition fieldDefinitionUnderlying = Introspection.getFieldDef(underlyingSchema, fieldsContainerUnderlying, newField.getName());
         GraphQLOutputType newOutputTypeUnderlying = fieldDefinitionUnderlying.getType();
 

--- a/src/main/java/graphql/nadel/engine/Transformer.java
+++ b/src/main/java/graphql/nadel/engine/Transformer.java
@@ -207,7 +207,7 @@ public class Transformer extends NodeVisitorStub {
 
         GraphQLFieldDefinition fieldDefinitionOverall = overallTypeInfo.getFieldDefinition();
         GraphQLNamedOutputType fieldTypeOverall = (GraphQLNamedOutputType) GraphQLTypeUtil.unwrapAll(fieldDefinitionOverall.getType());
-
+        String fieldContainerName = overallTypeInfo.getFieldsContainer().getName();
 
         NormalizedQueryFromAst normalizedOverallQuery = nadelContext.getNormalizedOverallQuery();
         List<NormalizedQueryField> normalizedFields = normalizedOverallQuery.getNormalizedFieldsByFieldId(getId(field));
@@ -237,21 +237,27 @@ public class Transformer extends NodeVisitorStub {
                 maybeAddUnderscoreTypeName(context, changedField, fieldTypeOverall);
             }
             if (applyResult.getTraversalControl() == TraversalControl.CONTINUE) {
-                updateTypeContext(context, typeContext.getOutputTypeUnderlying());
+                updateTypeContext(context, typeContext.getOutputTypeUnderlying(), fieldContainerName);
             }
             return applyResult.getTraversalControl();
 
         } else {
             maybeAddUnderscoreTypeName(context, field, fieldTypeOverall);
         }
-        updateTypeContext(context, typeContext.getOutputTypeUnderlying());
+        updateTypeContext(context, typeContext.getOutputTypeUnderlying(), fieldContainerName);
         return TraversalControl.CONTINUE;
     }
 
-
     private void updateTypeContext(TraverserContext<Node> context, GraphQLOutputType currentOutputTypeUnderlying) {
+        updateTypeContext(context, currentOutputTypeUnderlying, null);
+    }
+
+
+    private void updateTypeContext(TraverserContext<Node> context, GraphQLOutputType currentOutputTypeUnderlying, String fieldContainerName) {
         Field newField = (Field) context.thisNode();
         GraphQLFieldsContainer fieldsContainerUnderlying = (GraphQLFieldsContainer) unwrapAll(currentOutputTypeUnderlying);
+        assertTrue(fieldsContainerUnderlying instanceof GraphQLFieldsContainer, () -> String.format("Schema mismatch: Underlying schema is missing required field %s", fieldContainerName));
+
         GraphQLFieldDefinition fieldDefinitionUnderlying = Introspection.getFieldDef(underlyingSchema, fieldsContainerUnderlying, newField.getName());
         GraphQLOutputType newOutputTypeUnderlying = fieldDefinitionUnderlying.getType();
 

--- a/src/main/java/graphql/nadel/engine/Transformer.java
+++ b/src/main/java/graphql/nadel/engine/Transformer.java
@@ -252,7 +252,6 @@ public class Transformer extends NodeVisitorStub {
         updateTypeContext(context, currentOutputTypeUnderlying, null);
     }
 
-
     private void updateTypeContext(TraverserContext<Node> context, GraphQLOutputType currentOutputTypeUnderlying, String fieldContainerName) {
         Field newField = (Field) context.thisNode();
         GraphQLFieldsContainer fieldsContainerUnderlying = (GraphQLFieldsContainer) unwrapAll(currentOutputTypeUnderlying);
@@ -270,7 +269,6 @@ public class Transformer extends NodeVisitorStub {
                 .fieldDefinitionUnderlying(fieldDefinitionUnderlying)
                 .fieldArgumentValues(argumentValues);
         context.setVar(UnderlyingTypeContext.class, newTypeContext.build());
-
     }
 
     ApplyEnvironment createApplyEnvironment(Field field,

--- a/src/main/java/graphql/nadel/engine/Transformer.java
+++ b/src/main/java/graphql/nadel/engine/Transformer.java
@@ -207,7 +207,7 @@ public class Transformer extends NodeVisitorStub {
 
         GraphQLFieldDefinition fieldDefinitionOverall = overallTypeInfo.getFieldDefinition();
         GraphQLNamedOutputType fieldTypeOverall = (GraphQLNamedOutputType) GraphQLTypeUtil.unwrapAll(fieldDefinitionOverall.getType());
-
+        String fieldContainerName = overallTypeInfo.getFieldsContainer().getName();
 
         NormalizedQueryFromAst normalizedOverallQuery = nadelContext.getNormalizedOverallQuery();
         List<NormalizedQueryField> normalizedFields = normalizedOverallQuery.getNormalizedFieldsByFieldId(getId(field));
@@ -237,21 +237,27 @@ public class Transformer extends NodeVisitorStub {
                 maybeAddUnderscoreTypeName(context, changedField, fieldTypeOverall);
             }
             if (applyResult.getTraversalControl() == TraversalControl.CONTINUE) {
-                updateTypeContext(context, typeContext.getOutputTypeUnderlying());
+                updateTypeContext(context, typeContext.getOutputTypeUnderlying(), fieldContainerName);
             }
             return applyResult.getTraversalControl();
 
         } else {
             maybeAddUnderscoreTypeName(context, field, fieldTypeOverall);
         }
-        updateTypeContext(context, typeContext.getOutputTypeUnderlying());
+        updateTypeContext(context, typeContext.getOutputTypeUnderlying(), fieldContainerName);
         return TraversalControl.CONTINUE;
     }
 
-
     private void updateTypeContext(TraverserContext<Node> context, GraphQLOutputType currentOutputTypeUnderlying) {
+        updateTypeContext(context, currentOutputTypeUnderlying, null);
+    }
+
+
+    private void updateTypeContext(TraverserContext<Node> context, GraphQLOutputType currentOutputTypeUnderlying, String fieldContainerName) {
         Field newField = (Field) context.thisNode();
         GraphQLFieldsContainer fieldsContainerUnderlying = (GraphQLFieldsContainer) unwrapAll(currentOutputTypeUnderlying);
+        assertTrue(fieldsContainerUnderlying instanceof GraphQLFieldsContainer, () -> String.format("Schema Mismatch: Underlying schema is missing the required field %s", fieldContainerName));
+
         GraphQLFieldDefinition fieldDefinitionUnderlying = Introspection.getFieldDef(underlyingSchema, fieldsContainerUnderlying, newField.getName());
         GraphQLOutputType newOutputTypeUnderlying = fieldDefinitionUnderlying.getType();
 

--- a/src/main/java/graphql/nadel/engine/Transformer.java
+++ b/src/main/java/graphql/nadel/engine/Transformer.java
@@ -255,7 +255,7 @@ public class Transformer extends NodeVisitorStub {
     private void updateTypeContext(TraverserContext<Node> context, GraphQLOutputType currentOutputTypeUnderlying, String fieldContainerName) {
         Field newField = (Field) context.thisNode();
         GraphQLFieldsContainer fieldsContainerUnderlying = (GraphQLFieldsContainer) unwrapAll(currentOutputTypeUnderlying);
-        assertTrue(fieldsContainerUnderlying instanceof GraphQLFieldsContainer, () -> String.format("Schema mismatch: Underlying schema is missing required Interface Type %s", fieldContainerName));
+        assertTrue(fieldsContainerUnderlying instanceof GraphQLFieldsContainer, () -> String.format("Schema mismatch: The underlying schema is missing required interface type %s", fieldContainerName));
 
         GraphQLFieldDefinition fieldDefinitionUnderlying = Introspection.getFieldDef(underlyingSchema, fieldsContainerUnderlying, newField.getName());
         GraphQLOutputType newOutputTypeUnderlying = fieldDefinitionUnderlying.getType();

--- a/src/main/java/graphql/nadel/engine/Transformer.java
+++ b/src/main/java/graphql/nadel/engine/Transformer.java
@@ -255,7 +255,7 @@ public class Transformer extends NodeVisitorStub {
     private void updateTypeContext(TraverserContext<Node> context, GraphQLOutputType currentOutputTypeUnderlying, String fieldContainerName) {
         Field newField = (Field) context.thisNode();
         GraphQLFieldsContainer fieldsContainerUnderlying = (GraphQLFieldsContainer) unwrapAll(currentOutputTypeUnderlying);
-        assertTrue(fieldsContainerUnderlying instanceof GraphQLFieldsContainer, () -> String.format("Schema mismatch: Underlying schema is missing required field %s", fieldContainerName));
+        assertTrue(fieldsContainerUnderlying instanceof GraphQLFieldsContainer, () -> String.format("Schema mismatch: Underlying schema is missing required Object or Interface %s", fieldContainerName));
 
         GraphQLFieldDefinition fieldDefinitionUnderlying = Introspection.getFieldDef(underlyingSchema, fieldsContainerUnderlying, newField.getName());
         GraphQLOutputType newOutputTypeUnderlying = fieldDefinitionUnderlying.getType();

--- a/src/test/groovy/graphql/nadel/NadelE2ETest.groovy
+++ b/src/test/groovy/graphql/nadel/NadelE2ETest.groovy
@@ -1042,7 +1042,7 @@ class NadelE2ETest extends Specification {
         then:
         def e = thrown CompletionException
         e.cause instanceof AssertException
-        e.cause.message == "Schema mismatch: Underlying schema is missing required Interface Type Mars"
+        e.cause.message == "Schema mismatch: The underlying schema is missing required interface type Mars"
 
     }
 

--- a/src/test/groovy/graphql/nadel/NadelE2ETest.groovy
+++ b/src/test/groovy/graphql/nadel/NadelE2ETest.groovy
@@ -1042,7 +1042,7 @@ class NadelE2ETest extends Specification {
         then:
         def e = thrown CompletionException
         e.cause instanceof AssertException
-        e.cause.message == "Schema mismatch: Underlying schema is missing required field Mars"
+        e.cause.message == "Schema mismatch: Underlying schema is missing required Object or Interface Mars"
 
     }
 

--- a/src/test/groovy/graphql/nadel/NadelE2ETest.groovy
+++ b/src/test/groovy/graphql/nadel/NadelE2ETest.groovy
@@ -1042,7 +1042,7 @@ class NadelE2ETest extends Specification {
         then:
         def e = thrown CompletionException
         e.cause instanceof AssertException
-        e.cause.message == "Schema mismatch: Underlying schema is missing required Object or Interface Mars"
+        e.cause.message == "Schema mismatch: Underlying schema is missing required Interface Type Mars"
 
     }
 


### PR DESCRIPTION
If the underlying schema has a missing object or is removed then this message will help clarify which field it is when looking at the error.

https://github.com/graphql-java/nadel/issues/157