### PR TITLE
Fix bug with renaming field when theres a hydration call

### DIFF
--- a/src/main/java/graphql/nadel/engine/PathMapper.java
+++ b/src/main/java/graphql/nadel/engine/PathMapper.java
@@ -11,17 +11,25 @@ public class PathMapper {
     public ExecutionPath mapPath(ExecutionPath executionPath, String resultKey, UnapplyEnvironment environment) {
         List<Object> fieldSegments = patchLastFieldName(executionPath, resultKey);
 
-        if (environment.isHydrationTransformation) {
-            //
-            // Normally the parent path is all ok and hence there is nothing to add
-            // but if we have a hydrated a field then we need to "merge" the paths not just append them
-            // so for example
-            //
-            // /issue/reporter might lead to /userById and hence we need to collapse the top level hydrated field INTO the target field
-            List<Object> tmp = environment.parentNode.getExecutionPath().toList();
-            tmp.add(fieldSegments.get(fieldSegments.size() - 1));
-            fieldSegments = tmp;
+        List<Object> tmp = environment.parentNode.getExecutionPath().toList();
+
+        // if we have a executionPath like /issues/reporterId[0] and a parentNode executionPath
+        // like /issues/reporters[0] this replaces the first string field name
+        if (fieldSegments.get(fieldSegments.size() - 1) instanceof Integer) {
+            tmp.set(tmp.size() - 1, fieldSegments.get(fieldSegments.size() - 2));
         }
+
+        //
+        // If the case that we have a hydrated field,
+        // or a renamed parent field and are about to hydrate a child field
+        // we need to "merge" the paths not just append them
+        // so for example:
+        //
+        // /issue/reporterId might lead to /userById and hence we need to collapse the top level hydrated field INTO the target field
+        // /issue/reporterIds[0] might need to be changed to /issue/reporters[0]
+        tmp.add(fieldSegments.get(fieldSegments.size() - 1));
+        fieldSegments = tmp;
+
         return ExecutionPath.fromList(fieldSegments);
     }
 

--- a/src/main/java/graphql/nadel/engine/PathMapper.java
+++ b/src/main/java/graphql/nadel/engine/PathMapper.java
@@ -22,7 +22,6 @@ public class PathMapper {
             tmp.add(fieldSegments.get(fieldSegments.size() - 1));
             fieldSegments = tmp;
         }
-
         return ExecutionPath.fromList(fieldSegments);
     }
 

--- a/src/main/java/graphql/nadel/engine/transformation/HydrationTransformation.java
+++ b/src/main/java/graphql/nadel/engine/transformation/HydrationTransformation.java
@@ -90,6 +90,8 @@ public class HydrationTransformation extends FieldTransformation {
             if (node.getChildren().size() == 0) {
                 return handleEmptyList((ListExecutionResultNode) node, allTransformations, environment, matchingNormalizedOverallField);
             }
+            // Update the environment.parent to current node
+            environment.parentNode = node;
             ExecutionResultNode child = node.getChildren().get(0);
             if (child instanceof LeafExecutionResultNode) {
                 return handleListOfLeafs((ListExecutionResultNode) node, allTransformations, environment, matchingNormalizedOverallField);

--- a/src/test/groovy/graphql/nadel/e2e/NadelE2ERenameHydrationTest.groovy
+++ b/src/test/groovy/graphql/nadel/e2e/NadelE2ERenameHydrationTest.groovy
@@ -1,41 +1,16 @@
 package graphql.nadel.e2e
 
-import graphql.AssertException
-import graphql.ErrorType
-import graphql.GraphQLError
-import graphql.GraphqlErrorException
-import graphql.execution.AbortExecutionException
-import graphql.execution.ExecutionId
-import graphql.execution.ExecutionIdProvider
-import graphql.execution.instrumentation.InstrumentationState
-import graphql.language.Field
+
 import graphql.nadel.Nadel
 import graphql.nadel.NadelExecutionInput
 import graphql.nadel.ServiceExecution
 import graphql.nadel.ServiceExecutionResult
-import graphql.nadel.hooks.ServiceExecutionHooks
-import graphql.nadel.instrumentation.NadelInstrumentation
-import graphql.nadel.instrumentation.parameters.NadelInstrumentRootExecutionResultParameters
-import graphql.nadel.instrumentation.parameters.NadelInstrumentationCreateStateParameters
-import graphql.nadel.result.ResultNodesUtil
-import graphql.nadel.result.RootExecutionResultNode
-import graphql.nadel.schema.SchemaTransformationHook
 import graphql.nadel.testutils.TestUtil
-import graphql.nadel.testutils.harnesses.IssuesCommentsUsersHarness
-import graphql.schema.*
-import graphql.schema.idl.TypeDefinitionRegistry
-import graphql.util.TraversalControl
-import graphql.util.TraverserContext
 import spock.lang.Specification
 
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CompletionException
-
-import static graphql.language.AstPrinter.printAstCompact
 import static graphql.nadel.Nadel.newNadel
 import static graphql.nadel.NadelExecutionInput.newNadelExecutionInput
 import static graphql.nadel.testutils.TestUtil.typeDefinitions
-import static graphql.util.TreeTransformerUtil.changeNode
 import static java.util.concurrent.CompletableFuture.completedFuture
 
 class NadelE2ERenameHydrationTest extends Specification {

--- a/src/test/groovy/graphql/nadel/e2e/NadelE2ERenameHydrationTest.groovy
+++ b/src/test/groovy/graphql/nadel/e2e/NadelE2ERenameHydrationTest.groovy
@@ -124,7 +124,7 @@ class NadelE2ERenameHydrationTest extends Specification {
         1 * delegatedExecution.execute(_) >>
                 completedFuture(hydrationResult)
 
-        result.join().data == [updateSpecificIssue:[specificIssue:[name:[identity:"Luna"]]]]
+        result.join().data == [updateSpecificIssue: [specificIssue: [name: [identity: "Luna"]]]]
     }
 
 }

--- a/src/test/groovy/graphql/nadel/e2e/NadelE2ERenameHydrationTest.groovy
+++ b/src/test/groovy/graphql/nadel/e2e/NadelE2ERenameHydrationTest.groovy
@@ -1,0 +1,130 @@
+package graphql.nadel.e2e
+
+import graphql.AssertException
+import graphql.ErrorType
+import graphql.GraphQLError
+import graphql.GraphqlErrorException
+import graphql.execution.AbortExecutionException
+import graphql.execution.ExecutionId
+import graphql.execution.ExecutionIdProvider
+import graphql.execution.instrumentation.InstrumentationState
+import graphql.language.Field
+import graphql.nadel.Nadel
+import graphql.nadel.NadelExecutionInput
+import graphql.nadel.ServiceExecution
+import graphql.nadel.ServiceExecutionResult
+import graphql.nadel.hooks.ServiceExecutionHooks
+import graphql.nadel.instrumentation.NadelInstrumentation
+import graphql.nadel.instrumentation.parameters.NadelInstrumentRootExecutionResultParameters
+import graphql.nadel.instrumentation.parameters.NadelInstrumentationCreateStateParameters
+import graphql.nadel.result.ResultNodesUtil
+import graphql.nadel.result.RootExecutionResultNode
+import graphql.nadel.schema.SchemaTransformationHook
+import graphql.nadel.testutils.TestUtil
+import graphql.nadel.testutils.harnesses.IssuesCommentsUsersHarness
+import graphql.schema.*
+import graphql.schema.idl.TypeDefinitionRegistry
+import graphql.util.TraversalControl
+import graphql.util.TraverserContext
+import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+
+import static graphql.language.AstPrinter.printAstCompact
+import static graphql.nadel.Nadel.newNadel
+import static graphql.nadel.NadelExecutionInput.newNadelExecutionInput
+import static graphql.nadel.testutils.TestUtil.typeDefinitions
+import static graphql.util.TreeTransformerUtil.changeNode
+import static java.util.concurrent.CompletableFuture.completedFuture
+
+class NadelE2ERenameHydrationTest extends Specification {
+
+    def 'mutation with nested renamed fields, field types and a hydration call'() {
+        def simpleNDSL = '''
+         service IssuesService {
+            type Query {
+                findIssueOwner(id: ID): SpecificIssueOwner
+            }
+            
+            type SpecificIssueOwner => renamed from IssueOwner {
+                identity: String
+            }
+            
+            type SpecificIssue => renamed from Issue  {
+                id: ID
+                name: SpecificIssueOwner => hydrated from IssuesService.findIssueOwner(id: $source.id)
+            }
+
+            type UpdateSpecificIssuePayload => renamed from UpdateIssuePayload {
+                specificIssue: SpecificIssue => renamed from issue
+            }
+            type Mutation {
+                updateSpecificIssue: UpdateSpecificIssuePayload => renamed from updateIssue
+            }
+         }
+        '''
+
+        def underlyingSchema = typeDefinitions('''
+            type Query {
+                findIssueOwner(id: ID): IssueOwner
+            }
+            type IssueOwner {
+                identity: String
+            }
+            type Issue {
+                id: ID
+            }
+            type UpdateIssuePayload {
+                issue: Issue
+            }
+            type Mutation {
+                updateIssue: UpdateIssuePayload
+            }
+        ''')
+
+        def delegatedExecution = Mock(ServiceExecution)
+        def serviceFactory = TestUtil.serviceFactory(delegatedExecution, underlyingSchema)
+
+        def query = '''
+        mutation { 
+            updateSpecificIssue { 
+                specificIssue { 
+                    id
+                    name {
+                        identity
+                    }
+                }
+            } 
+        }
+        '''
+
+        given:
+        Nadel nadel = newNadel()
+                .dsl(simpleNDSL)
+                .serviceExecutionFactory(serviceFactory)
+                .build()
+        NadelExecutionInput nadelExecutionInput = newNadelExecutionInput()
+                .query(query)
+                .build()
+
+        def topLevelData = [updateIssue: [issue: [id: "1"]]]
+
+        def hydrationData = [findIssueOwner: [identity: "Luna"]]
+
+        ServiceExecutionResult topLevelResult = new ServiceExecutionResult(topLevelData)
+        ServiceExecutionResult hydrationResult = new ServiceExecutionResult(hydrationData)
+
+        when:
+        def result = nadel.execute(nadelExecutionInput)
+
+        then:
+        1 * delegatedExecution.execute(_) >>
+                completedFuture(topLevelResult)
+        1 * delegatedExecution.execute(_) >>
+                completedFuture(hydrationResult)
+
+        result.join().data == [updateSpecificIssue:[specificIssue:[name:[identity:"Luna"]]]]
+    }
+
+}

--- a/src/test/groovy/graphql/nadel/e2e/NadelE2ESyntheticHydrationTest.groovy
+++ b/src/test/groovy/graphql/nadel/e2e/NadelE2ESyntheticHydrationTest.groovy
@@ -1,7 +1,13 @@
-package graphql.nadel
+package graphql.nadel.e2e
 
 import graphql.execution.ExecutionId
 import graphql.execution.ExecutionIdProvider
+import graphql.nadel.Nadel
+import graphql.nadel.NadelExecutionInput
+import graphql.nadel.ServiceExecution
+import graphql.nadel.ServiceExecutionFactory
+import graphql.nadel.ServiceExecutionParameters
+import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.testutils.MockServiceExecution
 import graphql.nadel.testutils.TestUtil
 import graphql.schema.idl.TypeDefinitionRegistry

--- a/src/test/groovy/graphql/nadel/e2e/NadelE2ETest.groovy
+++ b/src/test/groovy/graphql/nadel/e2e/NadelE2ETest.groovy
@@ -1,4 +1,4 @@
-package graphql.nadel
+package graphql.nadel.e2e
 
 import graphql.AssertException
 import graphql.ErrorType
@@ -7,6 +7,12 @@ import graphql.GraphqlErrorException
 import graphql.execution.ExecutionId
 import graphql.execution.ExecutionIdProvider
 import graphql.execution.instrumentation.InstrumentationState
+import graphql.nadel.Nadel
+import graphql.nadel.NadelExecutionInput
+import graphql.nadel.ServiceExecution
+import graphql.nadel.ServiceExecutionFactory
+import graphql.nadel.ServiceExecutionParameters
+import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.instrumentation.NadelInstrumentation
 import graphql.nadel.instrumentation.parameters.NadelInstrumentRootExecutionResultParameters
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationCreateStateParameters


### PR DESCRIPTION
Basically, twofold:
 a) the path mapper is unable to find the correct environment when there is a list of hydration fields as it isn't updated to the current node, and
 b) if a field is renamed but it's child isn't immediately being hydrated this intermediate child's executionPath isn't updated resulting in a:
graphql.AssertException: Internal error: should never happen: could not find matching normalized field for parent node
