### PR TITLE
docs: replace obsolete User.usersById usage

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -51,7 +51,7 @@ service Issues {
     }
     type Issue {
         id: ID
-        authors: [User] => hydrated from Users.usersById(id: $source.authorIds) object identified by id, batch size 10
+        authors: [User] => hydrated from Users.users(ids: $source.authorIds) object identified by id, batch size 10
     }
 }
 


### PR DESCRIPTION
This was something that confused me while reading the docs. I couldn't understand what `Users.usersById` was referencing but I'm pretty sure it is just a mistake and it should be renamed to `User.users()`. Let me know if I'm mistaken. Thanks!