### PR TITLE
FMI-134 - Attempt to get stitching supporting arrays

### DIFF
--- a/src/main/antlr/StitchingDSL.g4
+++ b/src/main/antlr/StitchingDSL.g4
@@ -43,9 +43,13 @@ fieldMappingDefinition : 'renamed from' name ('.'name)?;
 //
 // hydration
 
-underlyingServiceHydration: 'hydrated from' serviceName '.' (syntheticField '.')? topLevelField remoteCallDefinition? objectIdentifier? batchSize?;
+underlyingServiceHydration: 'hydrated from' serviceName '.' (syntheticField '.')? topLevelField remoteCallDefinition? objectResolution? batchSize?;
 
-objectIdentifier: 'object identified by' ( indexReference | name );
+objectResolution: (objectByIdentifier | objectByIndex);
+
+objectByIdentifier: 'object identified by' name;
+
+objectByIndex: 'object indexed';
 
 batchSize: 'batch size ' intValue;
 
@@ -60,8 +64,6 @@ sourceObjectReference : '$source' '.' name ('.'name)*;
 fieldArgumentReference : '$argument' '.' name ;
 
 contextArgumentReference : '$context' '.' name ;
-
-indexReference: '$index' ;
 
 intValue: IntValue;
 

--- a/src/main/antlr/StitchingDSL.g4
+++ b/src/main/antlr/StitchingDSL.g4
@@ -49,7 +49,7 @@ objectResolution: (objectByIdentifier | objectByIndex);
 
 objectByIdentifier: 'object identified by' name;
 
-objectByIndex: 'object indexed';
+objectByIndex: 'using indexes';
 
 batchSize: 'batch size ' intValue;
 

--- a/src/main/antlr/StitchingDSL.g4
+++ b/src/main/antlr/StitchingDSL.g4
@@ -45,7 +45,7 @@ fieldMappingDefinition : 'renamed from' name ('.'name)?;
 
 underlyingServiceHydration: 'hydrated from' serviceName '.' (syntheticField '.')? topLevelField remoteCallDefinition? objectIdentifier? batchSize?;
 
-objectIdentifier: 'object identified by' name;
+objectIdentifier: 'object identified by' ( indexReference | name );
 
 batchSize: 'batch size ' intValue;
 
@@ -60,6 +60,8 @@ sourceObjectReference : '$source' '.' name ('.'name)*;
 fieldArgumentReference : '$argument' '.' name ;
 
 contextArgumentReference : '$context' '.' name ;
+
+indexReference: '$index' ;
 
 intValue: IntValue;
 

--- a/src/main/java/graphql/nadel/NadelAntlrToLanguage.java
+++ b/src/main/java/graphql/nadel/NadelAntlrToLanguage.java
@@ -166,7 +166,11 @@ public class NadelAntlrToLanguage extends GraphqlAntlrToLanguage {
         }
         String objectIdentifier = "id";
         if (ctx.objectIdentifier() != null) {
-            objectIdentifier = ctx.objectIdentifier().name().getText();
+            if (ctx.objectIdentifier().indexReference() != null) {
+                objectIdentifier = "$index";
+            } else {
+                objectIdentifier = ctx.objectIdentifier().name().getText();
+            }
         }
         Integer batchSize = null;
         if (ctx.batchSize() != null) {

--- a/src/main/java/graphql/nadel/NadelAntlrToLanguage.java
+++ b/src/main/java/graphql/nadel/NadelAntlrToLanguage.java
@@ -164,20 +164,25 @@ public class NadelAntlrToLanguage extends GraphqlAntlrToLanguage {
         for (StitchingDSLParser.RemoteArgumentPairContext remoteArgumentPairContext : remoteArgumentPairContexts) {
             remoteArguments.add(createRemoteArgumentDefinition(remoteArgumentPairContext));
         }
+
         String objectIdentifier = "id";
-        if (ctx.objectIdentifier() != null) {
-            if (ctx.objectIdentifier().indexReference() != null) {
-                objectIdentifier = "$index";
+        boolean objectIndexed = false;
+        StitchingDSLParser.ObjectResolutionContext objectResolution = ctx.objectResolution();
+        if (objectResolution != null) {
+            if (objectResolution.objectByIndex() != null) {
+                objectIdentifier = null;
+                objectIndexed = true;
             } else {
-                objectIdentifier = ctx.objectIdentifier().name().getText();
+                objectIdentifier = objectResolution.objectByIdentifier().name().getText();
             }
         }
+
         Integer batchSize = null;
         if (ctx.batchSize() != null) {
             batchSize = Integer.parseInt(ctx.batchSize().intValue().getText());
         }
         return new UnderlyingServiceHydration(getSourceLocation(ctx), new ArrayList<>(), serviceName, topLevelField, syntheticField,
-                remoteArguments, objectIdentifier, batchSize, additionalIdData());
+                remoteArguments, objectIdentifier, objectIndexed, batchSize, additionalIdData());
     }
 
     @Override

--- a/src/main/java/graphql/nadel/dsl/UnderlyingServiceHydration.java
+++ b/src/main/java/graphql/nadel/dsl/UnderlyingServiceHydration.java
@@ -53,6 +53,9 @@ public class UnderlyingServiceHydration extends AbstractNode<UnderlyingServiceHy
         return objectIdentifier;
     }
 
+    public boolean isObjectMatchByIndex() {
+        return objectIdentifier.equals("$index");
+    }
 
     public String getServiceName() {
         return serviceName;

--- a/src/main/java/graphql/nadel/dsl/UnderlyingServiceHydration.java
+++ b/src/main/java/graphql/nadel/dsl/UnderlyingServiceHydration.java
@@ -14,6 +14,9 @@ import graphql.util.TraverserContext;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+
+import static graphql.Assert.assertTrue;
 
 @Internal
 public class UnderlyingServiceHydration extends AbstractNode<UnderlyingServiceHydration> {
@@ -23,6 +26,7 @@ public class UnderlyingServiceHydration extends AbstractNode<UnderlyingServiceHy
     private final String syntheticField;
     private final List<RemoteArgumentDefinition> arguments;
     private final String objectIdentifier;
+    private final boolean objectIndexed;
     private final Integer batchSize;
 
     public UnderlyingServiceHydration(SourceLocation sourceLocation,
@@ -32,14 +36,18 @@ public class UnderlyingServiceHydration extends AbstractNode<UnderlyingServiceHy
                                       String syntheticField,
                                       List<RemoteArgumentDefinition> arguments,
                                       String objectIdentifier,
+                                      boolean objectIndexed,
                                       Integer batchSize,
                                       Map<String, String> additionalData
     ) {
         super(sourceLocation, comments, IgnoredChars.EMPTY, additionalData);
+        assertTrue(!objectIndexed ^ objectIdentifier == null, () -> "An object identifier cannot be provided if the hydration is by index");
+
         this.serviceName = serviceName;
         this.topLevelField = topLevelField;
         this.arguments = arguments;
         this.objectIdentifier = objectIdentifier;
+        this.objectIndexed = objectIndexed;
         this.batchSize = batchSize;
         this.syntheticField = syntheticField;
     }
@@ -54,7 +62,7 @@ public class UnderlyingServiceHydration extends AbstractNode<UnderlyingServiceHy
     }
 
     public boolean isObjectMatchByIndex() {
-        return objectIdentifier.equals("$index");
+        return objectIndexed;
     }
 
     public String getServiceName() {

--- a/src/main/java/graphql/nadel/engine/HydrationInputResolver.java
+++ b/src/main/java/graphql/nadel/engine/HydrationInputResolver.java
@@ -503,7 +503,7 @@ public class HydrationInputResolver {
         Map<String, String> typeRenameMappings = queryTransformationResult.getTypeRenameMappings();
 
         boolean first = true;
-        for (int i = 0, hydrationInputNodesSize = hydrationInputNodes.size(); i < hydrationInputNodesSize; i++) {
+        for (int i = 0; i < hydrationInputNodes.size(); i++) {
             HydrationInputNode hydrationInputNode = hydrationInputNodes.get(i);
 
             ExecutionResultNode matchingResolvedNode;

--- a/src/main/java/graphql/nadel/engine/HydrationInputResolver.java
+++ b/src/main/java/graphql/nadel/engine/HydrationInputResolver.java
@@ -495,7 +495,11 @@ public class HydrationInputResolver {
         List<ExecutionResultNode> resolvedNodes = listResultNode.getChildren();
 
         if (isResolveByIndex) {
-            assertTrue(resolvedNodes.size() == hydrationInputNodes.size(), () -> "Expect the size of the resolved nodes to match the size of the input when resolving by index");
+            assertTrue(resolvedNodes.size() == hydrationInputNodes.size(), () -> String.format(
+                    "If you use indexed hydration then you MUST follow a contract where the resolved nodes matches the size of the input arguments. We expected %d returned nodes but only got %d",
+                    hydrationInputNodes.size(),
+                    resolvedNodes.size()
+            ));
         }
 
         List<ExecutionResultNode> result = new ArrayList<>();

--- a/src/main/java/graphql/nadel/engine/HydrationInputResolver.java
+++ b/src/main/java/graphql/nadel/engine/HydrationInputResolver.java
@@ -445,7 +445,10 @@ public class HydrationInputResolver {
                 .additionalData(NodeId.ID, UUID.randomUUID().toString())
                 .arguments(allArguments)
                 .build();
-        topLevelField = addObjectIdentifier(getNadelContext(executionContext), topLevelField, underlyingServiceHydration.getObjectIdentifier());
+
+        if (!underlyingServiceHydration.isObjectMatchByIndex()) {
+            topLevelField = addObjectIdentifier(getNadelContext(executionContext), topLevelField, underlyingServiceHydration.getObjectIdentifier());
+        }
 
         if (syntheticFieldName == null) {
             return topLevelField;
@@ -464,7 +467,9 @@ public class HydrationInputResolver {
                                                                                    RootExecutionResultNode rootResultNode,
                                                                                    QueryTransformationResult queryTransformationResult,
                                                                                    ResultComplexityAggregator resultComplexityAggregator) {
-        boolean isSyntheticHydration = hydrationInputNodes.get(0).getHydrationTransformation().getUnderlyingServiceHydration().getSyntheticField() != null;
+        UnderlyingServiceHydration serviceHydration = hydrationInputNodes.get(0).getHydrationTransformation().getUnderlyingServiceHydration();
+        boolean isSyntheticHydration = serviceHydration.getSyntheticField() != null;
+        boolean isResolveByIndex = serviceHydration.isObjectMatchByIndex();
 
         ExecutionResultNode root = rootResultNode.getChildren().get(0);
         if (!(root instanceof LeafExecutionResultNode) && isSyntheticHydration) {
@@ -489,13 +494,25 @@ public class HydrationInputResolver {
         ListExecutionResultNode listResultNode = (ListExecutionResultNode) root;
         List<ExecutionResultNode> resolvedNodes = listResultNode.getChildren();
 
+        if (isResolveByIndex) {
+            assertTrue(resolvedNodes.size() == hydrationInputNodes.size(), () -> "Expect the size of the resolved nodes to match the size of the input when resolving by index");
+        }
+
         List<ExecutionResultNode> result = new ArrayList<>();
         Map<String, FieldTransformation> transformationByResultField = queryTransformationResult.getFieldIdToTransformation();
         Map<String, String> typeRenameMappings = queryTransformationResult.getTypeRenameMappings();
 
         boolean first = true;
-        for (HydrationInputNode hydrationInputNode : hydrationInputNodes) {
-            ObjectExecutionResultNode matchingResolvedNode = findMatchingResolvedNode(executionContext, hydrationInputNode, resolvedNodes);
+        for (int i = 0, hydrationInputNodesSize = hydrationInputNodes.size(); i < hydrationInputNodesSize; i++) {
+            HydrationInputNode hydrationInputNode = hydrationInputNodes.get(i);
+
+            ExecutionResultNode matchingResolvedNode;
+            if (isResolveByIndex) {
+            matchingResolvedNode = resolvedNodes.get(i);
+            } else {
+                matchingResolvedNode = findMatchingResolvedNode(executionContext, hydrationInputNode, resolvedNodes);
+            }
+
             ExecutionResultNode resultNode;
             if (matchingResolvedNode != null) {
                 ExecutionResultNode overallResultNode = serviceResultNodesToOverallResult.convertChildren(
@@ -542,7 +559,7 @@ public class HydrationInputResolver {
                 .build();
     }
 
-    private ObjectExecutionResultNode findMatchingResolvedNode(ExecutionContext executionContext, HydrationInputNode inputNode, List<ExecutionResultNode> resolvedNodes) {
+    private ExecutionResultNode findMatchingResolvedNode(ExecutionContext executionContext, HydrationInputNode inputNode, List<ExecutionResultNode> resolvedNodes) {
         NadelContext nadelContext = getNadelContext(executionContext);
         String objectIdentifier = nadelContext.getObjectIdentifierAlias();
         String inputNodeId = (String) inputNode.getCompletedValue();

--- a/src/main/java/graphql/nadel/engine/ServiceResultNodesToOverallResult.java
+++ b/src/main/java/graphql/nadel/engine/ServiceResultNodesToOverallResult.java
@@ -210,7 +210,7 @@ public class ServiceResultNodesToOverallResult {
         }
 
         if (result.changedNode instanceof ObjectExecutionResultNode) {
-            result.changedNode = addDeletedChildren((ObjectExecutionResultNode) result.changedNode, null, nadelContext, transformationMetadata);
+            result.changedNode = addDeletedChildren((ObjectExecutionResultNode) result.changedNode, normalizedRootField, nadelContext, transformationMetadata);
         }
         return result;
     }

--- a/src/main/java/graphql/nadel/engine/ServiceResultNodesToOverallResult.java
+++ b/src/main/java/graphql/nadel/engine/ServiceResultNodesToOverallResult.java
@@ -209,9 +209,9 @@ public class ServiceResultNodesToOverallResult {
             result = unapplyTransformations(executionId, node, transformations, unapplyEnvironment, fieldIdTransformation, nadelContext, transformationMetadata);
         }
 
-//        if (result.changedNode instanceof ObjectExecutionResultNode) {
-//            result.changedNode = addDeletedChildren((ObjectExecutionResultNode) result.changedNode, normalizedRootField, nadelContext, transformationMetadata);
-//        }
+        if (result.changedNode instanceof ObjectExecutionResultNode && !(parentNode instanceof HydrationInputNode)) {
+            result.changedNode = addDeletedChildren((ObjectExecutionResultNode) result.changedNode, null, nadelContext, transformationMetadata);
+        }
         return result;
     }
 

--- a/src/main/java/graphql/nadel/engine/ServiceResultNodesToOverallResult.java
+++ b/src/main/java/graphql/nadel/engine/ServiceResultNodesToOverallResult.java
@@ -209,9 +209,9 @@ public class ServiceResultNodesToOverallResult {
             result = unapplyTransformations(executionId, node, transformations, unapplyEnvironment, fieldIdTransformation, nadelContext, transformationMetadata);
         }
 
-        if (result.changedNode instanceof ObjectExecutionResultNode) {
-            result.changedNode = addDeletedChildren((ObjectExecutionResultNode) result.changedNode, normalizedRootField, nadelContext, transformationMetadata);
-        }
+//        if (result.changedNode instanceof ObjectExecutionResultNode) {
+//            result.changedNode = addDeletedChildren((ObjectExecutionResultNode) result.changedNode, normalizedRootField, nadelContext, transformationMetadata);
+//        }
         return result;
     }
 

--- a/src/test/groovy/graphql/nadel/dsl/UnderlyingServiceHydrationTest.groovy
+++ b/src/test/groovy/graphql/nadel/dsl/UnderlyingServiceHydrationTest.groovy
@@ -1,0 +1,68 @@
+package graphql.nadel.dsl
+
+import graphql.AssertException
+import graphql.language.SourceLocation;
+import spock.lang.Specification;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UnderlyingServiceHydrationTest extends Specification {
+    def "error if providing an identifier and the object indexed is null"() {
+        when:
+        new UnderlyingServiceHydration(
+                new SourceLocation(0, 0),
+                Collections.emptyList(),
+                "Service",
+                "Query",
+                "test",
+                Collections.emptyList(),
+                "test",
+                true,
+                5,
+                Collections.emptyMap()
+        )
+
+        then:
+        AssertException ex = thrown()
+
+        ex.message == "An object identifier cannot be provided if the hydration is by index"
+    }
+
+    def "no error thrown if indexed with an identifier"() {
+        when:
+        new UnderlyingServiceHydration(
+                new SourceLocation(0, 0),
+                Collections.emptyList(),
+                "Service",
+                "Query",
+                "test",
+                Collections.emptyList(),
+                "test",
+                false,
+                5,
+                Collections.emptyMap()
+        )
+
+        then:
+        notThrown AssertException
+    }
+
+    def "no error thrown if using index"() {
+        when:
+        new UnderlyingServiceHydration(
+                new SourceLocation(0, 0),
+                Collections.emptyList(),
+                "Service",
+                "Query",
+                "test",
+                Collections.emptyList(),
+                null,
+                true,
+                5,
+                Collections.emptyMap()
+        )
+
+        then:
+        notThrown AssertException
+    }
+}

--- a/src/test/groovy/graphql/nadel/engine/NadelExecutionStrategyTest2.groovy
+++ b/src/test/groovy/graphql/nadel/engine/NadelExecutionStrategyTest2.groovy
@@ -1172,7 +1172,7 @@ class NadelExecutionStrategyTest2 extends StrategyTestHelper {
         }
         service UserService {
             type Query {
-                usersByIssueIds(ids: [ID]): [User]
+                usersByIssueIds(issueIds: [ID]): [[User]]
             }
             type User {
                 id: ID

--- a/src/test/groovy/graphql/nadel/engine/NadelExecutionStrategyTest2.groovy
+++ b/src/test/groovy/graphql/nadel/engine/NadelExecutionStrategyTest2.groovy
@@ -1090,7 +1090,7 @@ class NadelExecutionStrategyTest2 extends StrategyTestHelper {
             }
             type Issue {
                 id: ID
-                authors: [User] => hydrated from UserService.usersByIds(ids: $source.authorIds) object identified by $index, batch size 5
+                authors: [User] => hydrated from UserService.usersByIds(ids: $source.authorIds) object indexed, batch size 5
             }
         }
         service UserService {
@@ -1167,7 +1167,7 @@ class NadelExecutionStrategyTest2 extends StrategyTestHelper {
             }
             type Issue {
                 id: ID
-                authors: [User] => hydrated from UserService.usersByIssueIds(issueIds: $source.id) object identified by $index, batch size 5
+                authors: [User] => hydrated from UserService.usersByIssueIds(issueIds: $source.id) object indexed, batch size 5
             }
         }
         service UserService {

--- a/src/test/groovy/graphql/nadel/engine/NadelExecutionStrategyTest2.groovy
+++ b/src/test/groovy/graphql/nadel/engine/NadelExecutionStrategyTest2.groovy
@@ -1062,6 +1062,161 @@ class NadelExecutionStrategyTest2 extends StrategyTestHelper {
         errors.size() == 0
     }
 
+    def "hydration matching using index"() {
+        given:
+        def issueSchema = TestUtil.schema("""
+        type Query {
+            issues : [Issue]
+        }
+        type Issue {
+            id: ID
+            authorIds: [ID]
+        }
+        """)
+        def userServiceSchema = TestUtil.schema("""
+        type Query {
+            usersByIds(ids: [ID]): [User]
+        }
+        type User {
+            id: ID
+            name: String
+        }
+        """)
+
+        def overallSchema = TestUtil.schemaFromNdsl('''
+        service Issues {
+            type Query {
+                issues: [Issue]
+            }
+            type Issue {
+                id: ID
+                authors: [User] => hydrated from UserService.usersByIds(ids: $source.authorIds) object identified by $index, batch size 5
+            }
+        }
+        service UserService {
+            type Query {
+                usersByIds(ids: [ID]): [User]
+            }
+            type User {
+                id: ID
+                name: String
+            }
+        }
+        ''')
+
+        def query = '{issues {id authors {name} }}'
+        def expectedQuery1 = "query nadel_2_Issues {issues {id authorIds}}"
+        def issue1 = [id: "ISSUE-1", authorIds: ['1']]
+        def issue2 = [id: "ISSUE-2", authorIds: ['1', '2']]
+
+        def expectedQuery2 = "query nadel_2_UserService {usersByIds(ids:[\"1\",\"1\",\"2\"]) {name}}"
+        def user1 = [id: "USER-1", name: 'Name']
+        def user2 = [id: "USER-2", name: 'Name 2']
+
+        Map response
+        List<GraphQLError> errors
+        when:
+        (response, errors) = test2Services(
+                overallSchema,
+                "Issues",
+                issueSchema,
+                "UserService",
+                userServiceSchema,
+                query,
+                ["issues"],
+                expectedQuery1,
+                [issues: [issue1, issue2]],
+                expectedQuery2,
+                [usersByIds: [user1, user1, user2]]
+        )
+
+
+        then:
+        def user1Result = [name: 'Name']
+        def user2Result = [name: 'Name 2']
+        def issue1Result = [id: "ISSUE-1", authors: [user1Result]]
+        def issue2Result = [id: "ISSUE-2", authors: [user1Result, user2Result]]
+        response == [issues: [issue1Result, issue2Result]]
+        errors.size() == 0
+    }
+
+    def "hydration matching using index with arrays"() {
+        given:
+        def issueSchema = TestUtil.schema("""
+        type Query {
+            issues : [Issue]
+        }
+        type Issue {
+            id: ID
+        }
+        """)
+        def userServiceSchema = TestUtil.schema("""
+        type Query {
+            usersByIssueIds(issueIds: [ID]): [[User]]
+        }
+        type User {
+            id: ID
+            name: String
+        }
+        """)
+
+        def overallSchema = TestUtil.schemaFromNdsl('''
+        service Issues {
+            type Query {
+                issues: [Issue]
+            }
+            type Issue {
+                id: ID
+                authors: [User] => hydrated from UserService.usersByIssueIds(issueIds: $source.id) object identified by $index, batch size 5
+            }
+        }
+        service UserService {
+            type Query {
+                usersByIssueIds(ids: [ID]): [User]
+            }
+            type User {
+                id: ID
+                name: String
+            }
+        }
+        ''')
+
+        def query = '{issues {id authors {name} }}'
+        def expectedQuery1 = "query nadel_2_Issues {issues {id id}}"
+        def issue1 = [id: "ISSUE-1"]
+        def issue2 = [id: "ISSUE-2"]
+
+        def expectedQuery2 = "query nadel_2_UserService {usersByIssueIds(issueIds:[\"ISSUE-1\",\"ISSUE-2\"]) {name}}"
+        def user1 = [name: 'Name']
+        def user2 = [name: 'Name 2']
+
+        Map response
+        List<GraphQLError> errors
+        when:
+        (response, errors) = test2Services(
+                overallSchema,
+                "Issues",
+                issueSchema,
+                "UserService",
+                userServiceSchema,
+                query,
+                ["issues"],
+                expectedQuery1,
+                [issues: [issue1, issue2]],
+                expectedQuery2,
+                [usersByIssueIds: [[user1], [user1, user2]]]
+        )
+
+
+        then:
+        def user1Result = [name: 'Name']
+        def user2Result = [name: 'Name 2']
+        def issue1Result = [id: "ISSUE-1", authors: [user1Result]]
+        def issue2Result = [id: "ISSUE-2", authors: [user1Result, user2Result]]
+        response == [issues: [issue1Result, issue2Result]]
+        errors.size() == 0
+    }
+
     Object[] test2ServicesWith3Calls(GraphQLSchema overallSchema,
                                      String serviceOneName,
                                      GraphQLSchema underlyingOne,

--- a/src/test/groovy/graphql/nadel/engine/NadelExecutionStrategyTest2.groovy
+++ b/src/test/groovy/graphql/nadel/engine/NadelExecutionStrategyTest2.groovy
@@ -1094,7 +1094,7 @@ class NadelExecutionStrategyTest2 extends StrategyTestHelper {
             }
             type Issue {
                 id: ID
-                authors: [User] => hydrated from UserService.usersByIds(ids: $source.authorIds) object indexed, batch size 5
+                authors: [User] => hydrated from UserService.usersByIds(ids: $source.authorIds) using indexes, batch size 5
             }
         }
         service UserService {
@@ -1172,7 +1172,7 @@ class NadelExecutionStrategyTest2 extends StrategyTestHelper {
             }
             type Issue {
                 id: ID
-                authors: [User] => hydrated from UserService.usersByIds(ids: $source.authorIds) object indexed, batch size 5
+                authors: [User] => hydrated from UserService.usersByIds(ids: $source.authorIds) using indexes, batch size 5
             }
         }
         service UserService {
@@ -1250,7 +1250,7 @@ class NadelExecutionStrategyTest2 extends StrategyTestHelper {
             }
             type Issue {
                 id: ID
-                authors: [User] => hydrated from UserService.usersByIds(ids: $source.authorIds) object indexed, batch size 5
+                authors: [User] => hydrated from UserService.usersByIds(ids: $source.authorIds)  using indexes, batch size 5
             }
         }
         service UserService {
@@ -1324,7 +1324,7 @@ class NadelExecutionStrategyTest2 extends StrategyTestHelper {
             }
             type Issue {
                 id: ID
-                authors: [User] => hydrated from UserService.usersByIssueIds(issueIds: $source.id) object indexed, batch size 5
+                authors: [User] => hydrated from UserService.usersByIssueIds(issueIds: $source.id) using indexes, batch size 5
             }
         }
         service UserService {

--- a/src/test/resources/hydration-synthetic.json
+++ b/src/test/resources/hydration-synthetic.json
@@ -38,6 +38,7 @@
                   "topLevelField": "resolveId",
                   "syntheticField": "resolver",
                   "objectIdentifier": "id",
+                  "objectMatchByIndex": false,
                   "arguments": [
                     {
                       "name": "otherId",

--- a/src/test/resources/hydration.json
+++ b/src/test/resources/hydration.json
@@ -37,6 +37,7 @@
                   "serviceName": "OtherService",
                   "topLevelField": "resolveId",
                   "objectIdentifier": "id",
+                  "objectMatchByIndex": false,
                   "arguments": [
                     {
                       "name": "otherId",


### PR DESCRIPTION
This PR is an attempt at supporting arrays of responses in for stitching - for example given the following code:

```
service Issues {
            type Query {
                issues: [Issue]
            }
            type Issue {
                id: ID
                authors: [User] => hydrated from UserService.usersByIssueIds(issueIds: $source.id) using indexes, batch size 5
            }
        }
        service UserService {
            type Query {
                usersByIssueIds(ids: [ID]): [[User]]
            }
            type User {
                id: ID
                name: String
            }
        }
```

To support this I've added the ability to identity an object by its index / position - which works as long as the service can guarantee the input and output order will always match.

There is still one remaining bug - `addDeletedChildren` is unable to figure out the `normalizedQueryField` when the response is an array. I'm keen for any help I might be able to get in fixing this.