### PR TITLE
GQLGW-672: fix hydration edge case when source field is also queried for

### DIFF
--- a/src/main/java/graphql/nadel/engine/ServiceResultNodesToOverallResult.java
+++ b/src/main/java/graphql/nadel/engine/ServiceResultNodesToOverallResult.java
@@ -59,7 +59,6 @@ public class ServiceResultNodesToOverallResult {
 
     private static final Logger log = LoggerFactory.getLogger(ServiceResultNodesToOverallResult.class);
 
-
     @SuppressWarnings("UnnecessaryLocalVariable")
     public ExecutionResultNode convert(ExecutionId executionId,
                                        ExecutionResultNode resultNode,
@@ -102,6 +101,7 @@ public class ServiceResultNodesToOverallResult {
 
         HandleResult handleResult = convertSingleNode(root, null/*not for root*/, executionId, root, normalizedRootField, overallSchema, isHydrationTransformation, batched, fieldIdToTransformation, typeRenameMappings, onlyChildren, nadelContext, transformationMetadata, nodeCount);
         assertNotNull(handleResult, () -> "can't delete root");
+        assertTrue(handleResult.siblings.isEmpty(), () -> "can't add siblings to root");
 
         ExecutionResultNode changedNode = handleResult.changedNode;
         List<ExecutionResultNode> newChildren = new ArrayList<>();
@@ -112,7 +112,7 @@ public class ServiceResultNodesToOverallResult {
                 continue;
             }
             newChildren.add(handleResultChild.changedNode);
-            newChildren.addAll(handleResult.siblings);
+            newChildren.addAll(handleResultChild.siblings);
         }
         return changedNode.transform(builder -> builder.children(newChildren).totalNodeCount(nodeCount.get()));
     }
@@ -251,7 +251,6 @@ public class ServiceResultNodesToOverallResult {
         return removedNode;
     }
 
-
     private HandleResult unapplyTransformations(ExecutionId executionId,
                                                 ExecutionResultNode node,
                                                 List<FieldTransformation> transformations,
@@ -371,7 +370,6 @@ public class ServiceResultNodesToOverallResult {
         }
     }
 
-
     private TuplesTwo<ExecutionResultNode, Map<AbstractNode, ExecutionResultNode>> splitTreeByTransformationDefinition(
             ExecutionResultNode executionResultNode,
             Map<String, FieldTransformation> fieldIdToTransformation,
@@ -421,10 +419,7 @@ public class ServiceResultNodesToOverallResult {
                 return TreeTransformerUtil.changeNode(context, changedNode);
             }
         });
-
-
     }
-
 
     private List<String> getFieldIdsWithoutTransformationId(ExecutionResultNode node, TransformationMetadata transformationMetadata) {
         return node.getFieldIds().stream().filter(fieldId -> FieldMetadataUtil.getTransformationIds(fieldId, transformationMetadata.getMetadataByFieldId()).size() == 0).collect(Collectors.toList());
@@ -443,7 +438,6 @@ public class ServiceResultNodesToOverallResult {
         mappedNode = resolvedValueMapper.mapCompletedValue(mappedNode, environment);
         return mappedNode;
     }
-
 
     private TuplesTwo<Set<FieldTransformation>, List<String>> getTransformationsAndNotTransformedFields(
             ExecutionResultNode node,
@@ -521,5 +515,4 @@ public class ServiceResultNodesToOverallResult {
             return handleResult;
         }
     }
-
 }


### PR DESCRIPTION
This was a bug where the `nestedBar` field would not be hydrated because the hydration used `$source.barId` and because the query also asked for `barId`.

Normally in hydration we expect that the $source `field` not be exposed so we usually replace the `field`. But in this case we can't just replace it, as its been queried for, so we need to add the hydrated field as a sibling and leave the $source `field` alone.

Before, we weren't handling the sibling properly.