### PR TITLE
Fix bug that redacts all top level fields

### DIFF
--- a/src/main/java/graphql/nadel/engine/NadelExecutionStrategy.java
+++ b/src/main/java/graphql/nadel/engine/NadelExecutionStrategy.java
@@ -13,7 +13,6 @@ import graphql.nadel.FieldInfo;
 import graphql.nadel.FieldInfos;
 import graphql.nadel.Operation;
 import graphql.nadel.Service;
-import graphql.nadel.ServiceExecutionResult;
 import graphql.nadel.dsl.NodeId;
 import graphql.nadel.engine.transformation.FieldTransformation;
 import graphql.nadel.engine.transformation.TransformationMetadata.NormalizedFieldAndError;
@@ -21,7 +20,8 @@ import graphql.nadel.hooks.CreateServiceContextParams;
 import graphql.nadel.hooks.ResultRewriteParams;
 import graphql.nadel.hooks.ServiceExecutionHooks;
 import graphql.nadel.instrumentation.NadelInstrumentation;
-import graphql.nadel.result.ElapsedTime;
+import graphql.nadel.normalized.NormalizedQueryField;
+import graphql.nadel.normalized.NormalizedQueryFromAst;
 import graphql.nadel.result.ExecutionResultNode;
 import graphql.nadel.result.ResultComplexityAggregator;
 import graphql.nadel.result.RootExecutionResultNode;
@@ -31,8 +31,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,6 +42,7 @@ import static graphql.Assert.assertNotNull;
 import static graphql.nadel.result.RootExecutionResultNode.newRootExecutionResultNode;
 import static graphql.nadel.util.FpKit.map;
 import static java.lang.String.format;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 
 @Internal
@@ -53,7 +52,6 @@ public class NadelExecutionStrategy {
     private final ServiceResultNodesToOverallResult serviceResultNodesToOverallResult = new ServiceResultNodesToOverallResult();
     private final OverallQueryTransformer queryTransformer = new OverallQueryTransformer();
     private final ServiceResultToResultNodes resultToResultNode = new ServiceResultToResultNodes();
-
 
     private final FieldInfos fieldInfos;
     private final GraphQLSchema overallSchema;
@@ -101,8 +99,6 @@ public class NadelExecutionStrategy {
                         log.debug("NadelExecutionStrategy time: {} ms, executionId: {}", elapsedTime, executionContext.getExecutionId());
                     });
         }).whenComplete(this::possiblyLogException);
-
-
     }
 
     private Map<Service, Object> serviceContextsByService(List<OneServiceExecution> oneServiceExecutions) {
@@ -132,7 +128,6 @@ public class NadelExecutionStrategy {
         return Async.each(result);
     }
 
-
     private List<CompletableFuture<RootExecutionResultNode>> executeTopLevelFields(
             ExecutionContext executionContext,
             NadelContext nadelContext,
@@ -153,28 +148,24 @@ public class NadelExecutionStrategy {
             // take the original query and transform it into the underlying query needed for that top level field
             //
             GraphQLSchema underlyingSchema = service.getUnderlyingSchema();
-            CompletableFuture<QueryTransformationResult> queryTransformCF = queryTransformer
+            CompletableFuture<QueryTransformationResult> transformedQueryCF = queryTransformer
                     .transformMergedFields(executionContext, underlyingSchema, operationName, operation, singletonList(mergedField), serviceExecutionHooks, service, serviceContext);
 
-            resultNodes.add(queryTransformCF.thenCompose(queryTransform -> {
+            resultNodes.add(transformedQueryCF.thenCompose(transformedQuery -> {
+                Map<String, FieldTransformation> fieldIdToTransformation = transformedQuery.getFieldIdToTransformation();
+                Map<String, String> typeRenameMappings = transformedQuery.getTypeRenameMappings();
 
-                Map<String, FieldTransformation> fieldIdToTransformation = queryTransform.getFieldIdToTransformation();
-                Map<String, String> typeRenameMappings = queryTransform.getTypeRenameMappings();
+                ExecutionContext newExecutionContext = buildServiceVariableOverrides(executionContext, transformedQuery.getVariableValues());
 
-                ExecutionContext newExecutionContext = buildServiceVariableOverrides(executionContext, queryTransform.getVariableValues());
-
-                String topLevelFieldId = NodeId.getId(esi.getFieldDefinition());
-                Optional<GraphQLError> maybeTopLevelFieldError = queryTransform.getRemovedFieldMap()
-                        .getRemovedFieldById(topLevelFieldId)
-                        .map(NormalizedFieldAndError::getError);
-                boolean topLevelFieldExecutionShouldBeSkipped = maybeTopLevelFieldError.isPresent();
-                if (topLevelFieldExecutionShouldBeSkipped) {
-                    GraphQLError topLevelFieldError = maybeTopLevelFieldError.get();
-                    return CompletableFuture.completedFuture(getSkippedServiceCallResult(nadelContext, esi, executionContext, topLevelFieldError));
+                Optional<GraphQLError> maybeFieldForbiddenError = getForbiddenTopLevelFieldError(esi, transformedQuery);
+                // If field is forbidden, do NOT execute it
+                if (maybeFieldForbiddenError.isPresent()) {
+                    GraphQLError fieldForbiddenError = maybeFieldForbiddenError.get();
+                    return CompletableFuture.completedFuture(getForbiddenTopLevelFieldResult(nadelContext, esi, fieldForbiddenError));
                 }
 
                 CompletableFuture<RootExecutionResultNode> serviceCallResult = serviceExecutor
-                        .execute(newExecutionContext, queryTransform, service, operation, serviceContext, false);
+                        .execute(newExecutionContext, transformedQuery, service, operation, serviceContext, false);
 
                 CompletableFuture<RootExecutionResultNode> convertedResult = serviceCallResult
                         .thenApply(resultNode -> {
@@ -187,7 +178,7 @@ public class NadelExecutionStrategy {
                                 benchmarkContext.serviceResultNodesToOverallResult.fieldIdToTransformation = fieldIdToTransformation;
                                 benchmarkContext.serviceResultNodesToOverallResult.typeRenameMappings = typeRenameMappings;
                                 benchmarkContext.serviceResultNodesToOverallResult.nadelContext = nadelContext;
-                                benchmarkContext.serviceResultNodesToOverallResult.transformationMetadata = queryTransform.getRemovedFieldMap();
+                                benchmarkContext.serviceResultNodesToOverallResult.transformationMetadata = transformedQuery.getRemovedFieldMap();
                             }
                             return (RootExecutionResultNode) serviceResultNodesToOverallResult
                                     .convert(newExecutionContext.getExecutionId(),
@@ -197,7 +188,7 @@ public class NadelExecutionStrategy {
                                             fieldIdToTransformation,
                                             typeRenameMappings,
                                             nadelContext,
-                                            queryTransform.getRemovedFieldMap());
+                                            transformedQuery.getRemovedFieldMap());
                         });
 
                 //set the result node count for this service
@@ -219,28 +210,46 @@ public class NadelExecutionStrategy {
                             return serviceExecutionHooks.resultRewrite(resultRewriteParams);
                         });
 
-
                 return serviceResult;
             }));
         }
         return resultNodes;
     }
 
-    private RootExecutionResultNode getSkippedServiceCallResult(NadelContext nadelContext, ExecutionStepInfo esi, ExecutionContext newExecutionContext, GraphQLError error) {
-        Map<String, Object> errorMap = error.toSpecification();
-
-        HashMap<String, Object> dataMap = new LinkedHashMap<>();
-        String topLevelFieldName = esi.getFieldDefinition().getName();
-        dataMap.put(topLevelFieldName, null);
-
-        return resultToResultNode.resultToResultNode(
-                newExecutionContext,
-                new ServiceExecutionResult(dataMap, Collections.singletonList(errorMap)),
-                ElapsedTime.newElapsedTime().build(),
-                nadelContext.getNormalizedOverallQuery()
-        );
+    /**
+     * A top level field error is present if the field should not be executed and an
+     * error should be put in lieu. We check this before calling out to the underlying
+     * service. This error is usually present when the field has been forbidden by
+     * {@link ServiceExecutionHooks#isFieldForbidden(NormalizedQueryField, Object)}.
+     *
+     * @param esi              the {@link ExecutionStepInfo} for the top level field
+     * @param transformedQuery the query for that specific top level field
+     * @return a {@link GraphQLError} if the field was forbidden before, otherwise empty
+     */
+    private Optional<GraphQLError> getForbiddenTopLevelFieldError(ExecutionStepInfo esi, QueryTransformationResult transformedQuery) {
+        GraphQLFieldDefinition fieldDefinition = esi.getFieldDefinition();
+        String topLevelFieldId = NodeId.getId(fieldDefinition);
+        return transformedQuery.getRemovedFieldMap()
+                .getRemovedFieldById(topLevelFieldId)
+                .map(NormalizedFieldAndError::getError);
     }
 
+    /**
+     * Creates the {@link RootExecutionResultNode} for a forbidden field. In that
+     * case the underlying service should not be called and we would fill the
+     * overall GraphQL response with an error for that specific top level field.
+     *
+     * @param nadelContext context for the execution
+     * @param esi          the {@link ExecutionStepInfo} for the top level field
+     * @param error        the {@link GraphQLError} to put in the overall response
+     * @return {@link RootExecutionResultNode} with the specified top level field nulled out and with the given GraphQL error
+     */
+    private RootExecutionResultNode getForbiddenTopLevelFieldResult(NadelContext nadelContext, ExecutionStepInfo esi, GraphQLError error) {
+        String topLevelFieldResultKey = esi.getResultKey();
+        NormalizedQueryFromAst overallQuery = nadelContext.getNormalizedOverallQuery();
+        NormalizedQueryField topLevelField = overallQuery.getTopLevelField(topLevelFieldResultKey);
+        return resultToResultNode.createResultWithNullTopLevelField(overallQuery, topLevelField, singletonList(error), emptyMap());
+    }
 
     @SuppressWarnings("unused")
     private <T> void possiblyLogException(T result, Throwable exception) {
@@ -279,7 +288,6 @@ public class NadelExecutionStrategy {
         });
     }
 
-
     private static class OneServiceExecution {
 
         public OneServiceExecution(Service service, Object serviceContext, ExecutionStepInfo stepInfo) {
@@ -292,7 +300,6 @@ public class NadelExecutionStrategy {
         final Object serviceContext;
         final ExecutionStepInfo stepInfo;
     }
-
 
     private Service getServiceForFieldDefinition(GraphQLFieldDefinition fieldDefinition) {
         FieldInfo info = assertNotNull(fieldInfos.getInfo(fieldDefinition), () -> String.format("no field info for field %s", fieldDefinition.getName()));
@@ -312,7 +319,6 @@ public class NadelExecutionStrategy {
     private NadelContext getNadelContext(ExecutionContext executionContext) {
         return executionContext.getContext();
     }
-
 }
 
 

--- a/src/main/java/graphql/nadel/engine/ServiceExecutor.java
+++ b/src/main/java/graphql/nadel/engine/ServiceExecutor.java
@@ -47,13 +47,13 @@ public class ServiceExecutor {
     private final Logger logNotSafe = LogKit.getNotPrivacySafeLogger(ServiceExecutor.class);
 
     private final ServiceResultToResultNodes resultToResultNode = new ServiceResultToResultNodes();
+    private final NormalizedQueryFactory normalizedQueryFactory = new NormalizedQueryFactory();
 
     private final NadelInstrumentation instrumentation;
 
     public ServiceExecutor(NadelInstrumentation instrumentation) {
         this.instrumentation = instrumentation;
     }
-
 
     public CompletableFuture<RootExecutionResultNode> execute(ExecutionContext executionContext,
                                                               QueryTransformationResult queryTransformerResult,
@@ -72,7 +72,6 @@ public class ServiceExecutor {
 
         ExecutionStepInfo underlyingRootStepInfo = createRootExecutionStepInfo(service.getUnderlyingSchema(), operation);
 
-        NormalizedQueryFactory normalizedQueryFactory = new NormalizedQueryFactory();
         NormalizedQueryFromAst normalizedQuery = normalizedQueryFactory.createNormalizedQuery(underlyingSchema, serviceExecutionParameters.getQuery(),
                 null,
                 serviceExecutionParameters.getVariables());
@@ -81,7 +80,6 @@ public class ServiceExecutor {
         return result
                 .thenApply(data -> serviceExecutionResultToResultNode(executionContextForService, underlyingRootStepInfo, transformedMergedFields, data, normalizedQuery));
     }
-
 
     private CompletableFuture<Data> executeImpl(Service service, ServiceExecution serviceExecution, ServiceExecutionParameters serviceExecutionParameters, ExecutionStepInfo executionStepInfo, ExecutionContext executionContext) {
 
@@ -143,7 +141,6 @@ public class ServiceExecutor {
         return new ServiceExecutionResult(new LinkedHashMap<>(), singletonList(errorMap), Collections.emptyMap());
     }
 
-
     private ServiceExecutionParameters buildServiceExecutionParameters(ExecutionContext executionContext, QueryTransformationResult queryTransformerResult, Object serviceContext, boolean isHydrationCall) {
 
         // only pass down variables that are referenced in the transformed query
@@ -152,7 +149,7 @@ public class ServiceExecutor {
         // only pass down fragments that have been used by the query after it is transformed
         Map<String, FragmentDefinition> fragments = queryTransformerResult.getTransformedFragments();
 
-        NadelContext nadelContext = (NadelContext) executionContext.getContext();
+        NadelContext nadelContext = executionContext.getContext();
         Object callerSuppliedContext = nadelContext.getUserSuppliedContext();
 
         return newServiceExecutionParameters()
@@ -210,5 +207,4 @@ public class ServiceExecutor {
                 elapsedTime,
                 normalizedQuery);
     }
-
 }

--- a/src/main/java/graphql/nadel/engine/Transformer.java
+++ b/src/main/java/graphql/nadel/engine/Transformer.java
@@ -54,7 +54,6 @@ import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 import graphql.util.TreeTransformerUtil;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -221,7 +220,7 @@ public class Transformer extends NodeVisitorStub {
             if (forbiddenFieldError == null) {
                 return false;
             }
-            transformationMetadata.add(Collections.singletonList(normalizedField), forbiddenFieldError);
+            transformationMetadata.removeField(normalizedField, forbiddenFieldError);
             return true;
         }).size();
 

--- a/src/main/java/graphql/nadel/engine/transformation/TransformationMetadata.java
+++ b/src/main/java/graphql/nadel/engine/transformation/TransformationMetadata.java
@@ -36,10 +36,8 @@ public class TransformationMetadata {
         }
     }
 
-    public void add(List<NormalizedQueryField> fields, GraphQLError error) {
-        for (NormalizedQueryField field : fields) {
-            removedFields.add(new NormalizedFieldAndError(field, error));
-        }
+    public void removeField(NormalizedQueryField field, GraphQLError error) {
+        removedFields.add(new NormalizedFieldAndError(field, error));
     }
 
     public List<NormalizedFieldAndError> getRemovedFieldsForParent(NormalizedQueryField parent) {
@@ -69,6 +67,5 @@ public class TransformationMetadata {
     public Map<String, List<FieldMetadata>> getMetadataByFieldId() {
         return metadataByFieldId;
     }
-
 }
 

--- a/src/main/java/graphql/nadel/normalized/NormalizedQueryFromAst.java
+++ b/src/main/java/graphql/nadel/normalized/NormalizedQueryFromAst.java
@@ -8,6 +8,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static graphql.Assert.assertNotNull;
+import static graphql.Assert.assertNull;
+
 @Internal
 public class NormalizedQueryFromAst {
 
@@ -42,5 +45,19 @@ public class NormalizedQueryFromAst {
     public List<String> getFieldIds(NormalizedQueryField normalizedQueryField) {
         MergedField mergedField = mergedFieldByNormalizedFields.get(normalizedQueryField);
         return NodeId.getIds(mergedField);
+    }
+
+    public NormalizedQueryField getTopLevelField(String topLevelFieldResultKey) {
+        NormalizedQueryField topLevelField = null;
+
+        for (NormalizedQueryField candidate : getTopLevelFields()) {
+            if (candidate.getResultKey().equals(topLevelFieldResultKey)) {
+                assertNull(topLevelField, () -> "Found more than one normalized top level field with the same name");
+                topLevelField = candidate;
+            }
+        }
+        assertNotNull(topLevelField, () -> "Could not find top level field");
+
+        return topLevelField;
     }
 }

--- a/src/test/groovy/graphql/nadel/engine/NadelExecutionStrategyTest2.groovy
+++ b/src/test/groovy/graphql/nadel/engine/NadelExecutionStrategyTest2.groovy
@@ -22,12 +22,10 @@ import graphql.nadel.result.ResultComplexityAggregator
 import graphql.nadel.testutils.TestUtil
 import graphql.schema.GraphQLSchema
 
-import javax.xml.transform.Result
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
 
 import static graphql.language.AstPrinter.printAstCompact
-import static graphql.language.AstPrinter.printAst
 import static java.util.concurrent.CompletableFuture.completedFuture
 
 class NadelExecutionStrategyTest2 extends StrategyTestHelper {
@@ -1415,10 +1413,10 @@ class NadelExecutionStrategyTest2 extends StrategyTestHelper {
         def expectedQuery3 = "query nadel_2_Bar {barsById(id:[\"nestedBar1\"]) {name nestedBarId object_identifier__UUID:barId}}"
         def expectedQuery4 = "query nadel_2_Bar {barsById(id:[\"nestedBarId456\"]) {name details {age contact {email phone}} object_identifier__UUID:barId}}"
 
-        def response1 = [foos: [[details:[name:"smith", age:1, contact:[email:"test", phone:1]] ,barId: "bar1"]]]
+        def response1 = [foos: [[details: [name: "smith", age: 1, contact: [email: "test", phone: 1]], barId: "bar1"]]]
         def response2 = [barsById: [[object_identifier__UUID: "bar1", name: "Bar 1", nestedBarId: "nestedBar1"]]]
         def response3 = [barsById: [[object_identifier__UUID: "nestedBar1", name: "NestedBarName1", nestedBarId: "nestedBarId456"]]]
-        def response4 = [barsById: [[object_identifier__UUID: "nestedBarId456", name: "NestedBarName2", details:[age:1, contact:[email:"test", phone:1]]]]]
+        def response4 = [barsById: [[object_identifier__UUID: "nestedBarId456", name: "NestedBarName2", details: [age: 1, contact: [email: "test", phone: 1]]]]]
 
         Map response
         List<GraphQLError> errors
@@ -1840,7 +1838,6 @@ class NadelExecutionStrategyTest2 extends StrategyTestHelper {
     }
 
 
-
     Object[] test2ServicesWithNCalls(GraphQLSchema overallSchema,
                                      String serviceOneName,
                                      GraphQLSchema underlyingOne,
@@ -1954,9 +1951,9 @@ class NadelExecutionStrategyTest2 extends StrategyTestHelper {
                 "        }"
 
         def expectedQuery1 = "query nadel_2_IssuesService {issue {ticket {ticketTypes {id date}}}}"
-        def response1 =   [issue: [[ticket: [ticketTypes: [[id:"1", date:"20/11/2020"]]]]]]
+        def response1 = [issue: [[ticket: [ticketTypes: [[id: "1", date: "20/11/2020"]]]]]]
 
-        def overallResponse = [renamedIssue: [[renamedTicket: [renamedTicketTypes: [[renamedId:"1", renamedDate:"20/11/2020"]]]]]]
+        def overallResponse = [renamedIssue: [[renamedTicket: [renamedTicketTypes: [[renamedId: "1", renamedDate: "20/11/2020"]]]]]]
 
 
         Map response
@@ -2055,7 +2052,7 @@ class NadelExecutionStrategyTest2 extends StrategyTestHelper {
         ])
 
         def expectedQuery2 = "query nadel_2_IssueService {syntheticIssue {issue(id:\"1\") {id}}}"
-        def response2 = new ServiceExecutionResult([syntheticIssue:[issue: [id: "1"]]])
+        def response2 = new ServiceExecutionResult([syntheticIssue: [issue: [id: "1"]]])
 
         def executionData = createExecutionData(query, [:], overallSchema)
 
@@ -2139,12 +2136,74 @@ class NadelExecutionStrategyTest2 extends StrategyTestHelper {
         def actualError = actualErrors[0]
         actualError.message == expectedError.message
         actualError.path == expectedError.path
-        // The error type is actually put into the extensions
-        actualError.extensions == new HashMap<>(expectedError.extensions).tap {
-            put("classification", expectedError.errorType.toSpecification(null))
-        }
+        actualError.extensions == expectedError.extensions
         actualError.locations == expectedError.locations
         actualError.errorType == expectedError.errorType
+    }
+
+    def "top level field error does not redact other top level fields"() {
+        given:
+        def underlyingSchema = TestUtil.schema("""
+        type Query {
+            foo: String
+        }
+        """)
+
+        def overallSchema = TestUtil.schemaFromNdsl("""
+        service service1 {
+            type Query {
+                foo: String
+            }
+        }
+        """)
+        def fooFieldDefinition = overallSchema.getQueryType().getFieldDefinition("foo")
+
+        def service = new Service("service", underlyingSchema, service1Execution, serviceDefinition, definitionRegistry)
+        def fieldInfos = topLevelFieldInfo(fooFieldDefinition, service)
+
+        def expectedError = GraphqlErrorBuilder.newError()
+                .message("Hello world")
+                .path(["test", "hello"])
+                .build()
+
+        def serviceExecutionHooks = new ServiceExecutionHooks() {
+            @Override
+            CompletableFuture<Optional<GraphQLError>> isFieldForbidden(NormalizedQueryField normalizedField, Object userSuppliedContext) {
+                if (normalizedField.getResultKey() == "foo") {
+                    completedFuture(Optional.of(expectedError))
+                } else {
+                    completedFuture(Optional.empty())
+                }
+            }
+        }
+
+        NadelExecutionStrategy nadelExecutionStrategy = new NadelExecutionStrategy([service], fieldInfos, overallSchema, instrumentation, serviceExecutionHooks)
+
+        def executionData = createExecutionData(query, overallSchema)
+
+        def expectedQuery1 = "query nadel_2_service {bar:foo}"
+        def response1 = new ServiceExecutionResult([bar: "boo"])
+
+        when:
+        def response = nadelExecutionStrategy.execute(executionData.executionContext, executionData.fieldSubSelection, resultComplexityAggregator)
+
+        then:
+        1 * service1Execution.execute({ ServiceExecutionParameters sep ->
+            println printAstCompact(sep.query)
+            printAstCompact(sep.query) == expectedQuery1
+        }) >> completedFuture(response1)
+
+        resultData(response) == [foo: null, bar: "boo"]
+
+        def errors = resultErrors(response)
+        errors.size() == 1
+        errors[0].message == expectedError.message
+        errors[0].path == expectedError.path
+
+        where:
+        _ | query // Depending on how it the final tree gets merged, the old code would sometimes pass too
+        _ | "{bar: foo foo}"
+        _ | "{foo bar: foo}"
     }
 
 }


### PR DESCRIPTION
So the bug goes

You ask for two fields

```
{
  bar
  foo
}
```

Say the top level field `foo` is rejected, and executing `bar` returns data. The issues comes when we build the skipped/rejected response for `foo`, when that happens the old code actually looks through _all_ the and inserts what it can find, which is null. When it comes to merging the trees, the null field is taken.

This is all because the call to `resultToResultNode.resultToResultNode` uses the overall query, and not the specific top level field query.