### PR TITLE
Fixed schema generator so that the generated operation types always have a source location

### DIFF
--- a/src/main/java/graphql/nadel/schema/OverallSchemaGenerator.java
+++ b/src/main/java/graphql/nadel/schema/OverallSchemaGenerator.java
@@ -7,6 +7,7 @@ import graphql.language.FieldDefinition;
 import graphql.language.ObjectTypeDefinition;
 import graphql.language.SDLDefinition;
 import graphql.language.SchemaDefinition;
+import graphql.language.SourceLocation;
 import graphql.nadel.DefinitionRegistry;
 import graphql.nadel.Operation;
 import graphql.schema.GraphQLSchema;
@@ -54,7 +55,10 @@ public class OverallSchemaGenerator {
         fieldsMapByType.keySet().forEach(key -> {
             List<FieldDefinition> fields = fieldsMapByType.get(key);
             if (fields.size() > 0) {
-                overallRegistry.add(newObjectTypeDefinition().name(key.getDisplayName()).fieldDefinitions(fields).build());
+                overallRegistry.add(newObjectTypeDefinition()
+                        .name(key.getDisplayName())
+                        .sourceLocation(new SourceLocation(-1,-1,"generated"))
+                        .fieldDefinitions(fields).build());
             }
         });
 

--- a/src/test/groovy/graphql/nadel/schema/OverallSchemaGeneratorTest.groovy
+++ b/src/test/groovy/graphql/nadel/schema/OverallSchemaGeneratorTest.groovy
@@ -258,6 +258,9 @@ class OverallSchemaGeneratorTest extends Specification {
             it.name
         } == ['x', 'y', 'z']
 
+        // source location is generated
+        schema.getQueryType().getDefinition() != null
+        schema.getQueryType().getDefinition().getSourceLocation() != null
     }
 
     def "only extend Query works"() {


### PR DESCRIPTION
When we "combine N" query types, we generate a new object definition.  This makes sure the SourceLocation is non null