### PR TITLE
GQLGW-776: fix duplicated errors for N redacted nodes

### DIFF
--- a/src/test/groovy/graphql/nadel/RemovedFieldsTest.groovy
+++ b/src/test/groovy/graphql/nadel/RemovedFieldsTest.groovy
@@ -552,7 +552,6 @@ class RemovedFieldsTest extends StrategyTestHelper {
 
 
     ServiceExecutionHooks createServiceExecutionHooksWithFieldRemoval(List<String> fieldsToRemove) {
-
         return new ServiceExecutionHooks() {
             @Override
             CompletableFuture<Optional<GraphQLError>> isFieldForbidden(NormalizedQueryField normalizedField, Object userSuppliedContext) {
@@ -689,16 +688,7 @@ class RemovedFieldsTest extends StrategyTestHelper {
         """)
         def query = "{issues {id restricted}}"
 
-        def hooks = new ServiceExecutionHooks() {
-            @Override
-            CompletableFuture<Optional<GraphQLError>> isFieldForbidden(NormalizedQueryField normalizedField, Object userSuppliedContext) {
-                if (normalizedField.getName() == "restricted" && normalizedField.getParent().getName() == "issues") {
-                    //temporary GraphQLError ->  need to implement a field permissions denied error
-                    return CompletableFuture.completedFuture(Optional.of(new AbortExecutionException("removed field")))
-                }
-                return CompletableFuture.completedFuture(Optional.empty())
-            }
-        }
+        def hooks = createServiceExecutionHooksWithFieldRemoval(["restricted"])
 
         def expectedQuery1 = "query nadel_2_Issues {issues {id}}"
         def response1 = [issues: [[id: "test-1",], [id: "test-2",], [id: "test-3",]]]


### PR DESCRIPTION
The way this works it checks that the Node we're inserting the error for is the 0th node, not sure if this is fully correct so wanted some eyes on it.

The alternative is having mutable state inside `TransformationMetadata` about whether the error has been inserted in the tree, which felt icky. But tbh so is this solution because I can't be fully confident it's doing what we want.